### PR TITLE
Use "oldest-supported-numpy" instead of plain numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11 >= 2.6.1", "numpy >= 1.14"]
+requires = ["setuptools>=42", "wheel", "pybind11 >= 2.6.1", ""oldest-supported-numpy""]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11 >= 2.6.1", ""oldest-supported-numpy""]
+requires = ["setuptools>=42", "wheel", "pybind11 >= 2.6.1", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This changes the build to use the oldest supported numpy version. With this, the resulting binary will be compatible with all newer NumPy version. This is quite helpful as NumPy's (ABI) compatibility is so that it will support any NumPy version that is newer than the one used during the build.

In the conda-forge recipe, it should be sufficient to have `numpy` in `host`. There the global pinning is doing a similar job.