### PR TITLE
Fixed a problem of ddLPB for solute distributions beyond point charges.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
         "directory. Example: mkdir build && cd build && cmake ..")
 endif()
 
-project(ddX VERSION 0.4.0 LANGUAGES Fortran CXX)
+project(ddX VERSION 0.4.1 LANGUAGES Fortran CXX)
 # If ddX is a subproject, append ddx_ prefix to all targets.
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(ddx_is_subproject false)

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = ddx
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.4.0
+PROJECT_NUMBER         = 0.4.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     description="ddx continuum solvation library",
     long_description=read_readme(),
     long_description_content_type="text/markdown",
-    version="0.4.0",
+    version="0.4.1",
     #
     author="ddx developers",
     author_email="best@ians.uni-stuttgart.de",

--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -2961,7 +2961,7 @@ subroutine get_banner(string)
     implicit none
     character (len=2047), intent(out) :: string
     character (len=10) :: vstr
-    write(vstr, *) "0.4.0"
+    write(vstr, *) "0.4.1"
     write(string, *) &
         & " +----------------------------------------------------------------+", &
         & NEW_LINE('a'), &


### PR DESCRIPTION
In ddLPB the polarization density is expanded without the 4pi/(2l + 1) factors which characterize ddPCM and ddCOSMO.
Before using the density in the same way it is done in ddPCM and ddCOSMO, these factors must be reintroduced.

Previously, the density was scaled by the constant factor 4pi, however, this is good only for solutes which are described by point charges only.