### PR TITLE
 Parallelized all the adjoint operations and the FMM l2l and m2m operations. 

### DIFF
--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -2720,9 +2720,9 @@ subroutine tree_m2p_adj(params, constants, p, alpha, grid_v, beta, sph_m)
         sph_m = beta * sph_m
     end if
     ! Cycle over all spheres
-    !!$omp parallel do default(none) shared(params,constants,grid_v,p, &
-    !!$omp alpha,sph_m), private(isph,inode,jnear,jnode,jsph,igrid,c,work) &
-    !!$omp schedule(dynamic)
+    !$omp parallel do default(none) shared(params,constants,grid_v,p, &
+    !$omp alpha,sph_m), private(isph,inode,jnear,jnode,jsph,igrid,c,work) &
+    !$omp schedule(dynamic)
     do isph = 1, params % nsph
         ! Cycle over all near-field admissible pairs of spheres
         inode = constants % snode(isph)
@@ -2735,12 +2735,12 @@ subroutine tree_m2p_adj(params, constants, p, alpha, grid_v, beta, sph_m)
             if(isph .eq. jsph) cycle
             ! Accumulate interaction for external grid points only
             do igrid = 1, params % ngrid
-                if(constants % ui(igrid, isph) .eq. zero) cycle
-                c = constants % cgrid(:, igrid)*params % rsph(isph) - &
-                    & params % csph(:, jsph) + params % csph(:, isph)
-                call fmm_m2p_adj_work(c, alpha*grid_v(igrid, isph), &
-                    & params % rsph(jsph), p, constants % vscales_rel, one, &
-                    & sph_m(:, jsph), work)
+                if(constants % ui(igrid, jsph) .eq. zero) cycle
+                c = constants % cgrid(:, igrid)*params % rsph(jsph) - &
+                    & params % csph(:, isph) + params % csph(:, jsph)
+                call fmm_m2p_adj_work(c, alpha*grid_v(igrid, jsph), &
+                    & params % rsph(isph), p, constants % vscales_rel, one, &
+                    & sph_m(:, isph), work)
             end do
         end do
     end do

--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -2372,10 +2372,9 @@ subroutine tree_m2l_bessel_rotation_adj_work(params, constants, node_l, node_m)
     ! Local variables
     integer :: i, j, k
     real(dp) :: c1(3), c(3), r
-    ! Any order of this cycle is OK
     node_m = zero
-    !!$omp parallel do shared(constants,params,node_l,node_m) &
-    !!$omp private(i,c,r,k,c1,work,work_complex,j) schedule(dynamic)
+    !$omp parallel do shared(constants,params,node_l,node_m) &
+    !$omp private(i,c,r,k,c1,work,work_complex,j) schedule(dynamic)
     do i = 1, constants % nclusters
         ! If no far admissible pairs just set output to zero
         if (constants % nfar(i) .eq. 0) then
@@ -2386,19 +2385,18 @@ subroutine tree_m2l_bessel_rotation_adj_work(params, constants, node_l, node_m)
         ! Use the first far admissible pair to initialize output
         k = constants % far(constants % sfar(i))
         c1 = constants % cnode(:, k)
-        c1 = params % kappa*(c1 - c)
-        call fmm_m2l_bessel_rotation_adj_work(c1, constants % SI_rnode(:, i), &
-            & constants % SK_rnode(:, k), params % pm, &
-            & constants % vscales, one, &
-            & node_l(:, i), one, node_m(:, k), work, work_complex)
+        c1 = params % kappa*(c - c1)
+        call fmm_m2l_bessel_rotation_adj_work(c1, constants % SI_rnode(:, k), &
+            & constants % SK_rnode(:, i), params % pm, constants % vscales, &
+            & one, node_l(:, k), one, node_m(:, i), work, work_complex)
         do j = constants % sfar(i)+1, constants % sfar(i+1)-1
             k = constants % far(j)
             c1 = constants % cnode(:, k)
-            c1 = params % kappa*(c1 - c)
-            call fmm_m2l_bessel_rotation_adj_work(c1, constants % SI_rnode(:, i), &
-                & constants % SK_rnode(:, k), params % pm, &
-                & constants % vscales, one, &
-                & node_l(:, i), one, node_m(:, k), work, work_complex)
+            c1 = params % kappa*(c - c1)
+            call fmm_m2l_bessel_rotation_adj_work(c1, &
+                & constants % SI_rnode(:, k), constants % SK_rnode(:, i), &
+                & params % pm, constants % vscales, one, node_l(:, k), &
+                & one, node_m(:, i), work, work_complex)
         end do
     end do
 end subroutine tree_m2l_bessel_rotation_adj_work

--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -2774,28 +2774,25 @@ subroutine tree_m2p_bessel_adj(params, constants, p, alpha, grid_v, beta, sph_p,
         sph_m = beta * sph_m
     end if
     ! Cycle over all spheres
-    !!$omp parallel do default(none) shared(params,constants,p,sph_m,tmp, &
-    !!$omp alpha,grid_v) private(isph,inode,jnear,jnode,jsph,igrid,c, &
-    !!$omp iproc) schedule(dynamic)
+    !$omp parallel do default(none) shared(params,constants,p,sph_m, &
+    !$omp alpha,grid_v) private(isph,inode,jnear,jnode,jsph,igrid,c) &
+    !$omp schedule(dynamic)
     do isph = 1, params % nsph
         ! Cycle over all near-field admissible pairs of spheres
         inode = constants % snode(isph)
-        ! iproc = omp_get_thread_num() + 1
         do jnear = constants % snear(inode), constants % snear(inode+1)-1
             ! Near-field interactions are possible only between leaf nodes,
             ! which must contain only a single input sphere
             jnode = constants % near(jnear)
             jsph = constants % order(constants % cluster(1, jnode))
-            ! Ignore self-interaction
-            !if(isph .eq. jsph) cycle
             ! Accumulate interaction for external grid points only
             do igrid = 1, params % ngrid
-                if(constants % ui(igrid, isph) .eq. zero) cycle
-                c = constants % cgrid(:, igrid)*params % rsph(isph) - &
-                    & params % csph(:, jsph) + params % csph(:, isph)
-                call fmm_m2p_bessel_adj(c, alpha*grid_v(igrid, isph), &
-                    & params % rsph(jsph), params % kappa, p, &
-                    & constants % vscales, one, sph_m(:, jsph))
+                if(constants % ui(igrid, jsph) .eq. zero) cycle
+                c = constants % cgrid(:, igrid)*params % rsph(jsph) - &
+                    & params % csph(:, isph) + params % csph(:, jsph)
+                call fmm_m2p_bessel_adj(c, alpha*grid_v(igrid, jsph), &
+                    & params % rsph(isph), params % kappa, p, &
+                    & constants % vscales, one, sph_m(:, isph))
             end do
         end do
     end do

--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -187,6 +187,8 @@ type ddx_state_type
     real(dp), allocatable :: x_adj_r_grid(:, :)
     real(dp), allocatable :: x_adj_e_grid(:, :)
     real(dp), allocatable :: phi_n(:, :)
+    real(dp) :: hsp_time
+    real(dp) :: hsp_adj_time
 
 end type ddx_state_type
 

--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -2415,8 +2415,9 @@ subroutine tree_m2l_rotation_adj(params, constants, node_l, node_m)
     ! Local variables
     integer :: i, j, k
     real(dp) :: c1(3), c(3), r1, r
-    ! Any order of this cycle is OK
     node_m = zero
+    !$omp parallel do default(none) shared(constants,params,node_m,node_l) &
+    !$omp private(i,c,r,k,c1,r1,j) schedule(dynamic)
     do i = 1, constants % nclusters
         ! If no far admissible pairs just set output to zero
         if (constants % nfar(i) .eq. 0) then
@@ -2428,18 +2429,18 @@ subroutine tree_m2l_rotation_adj(params, constants, node_l, node_m)
         k = constants % far(constants % sfar(i))
         c1 = constants % cnode(:, k)
         r1 = constants % rnode(k)
-        c1 = c - c1
-        call fmm_m2l_rotation_adj(c1, r, r1, params % pl, params % pm, &
+        c1 = c1 - c
+        call fmm_m2l_rotation_adj(c1, r1, r, params % pl, params % pm, &
             & constants % vscales, constants % m2l_ztranslate_adj_coef, one, &
-            & node_l(:, i), one, node_m(:, k))
+            & node_l(:, k), one, node_m(:, i))
         do j = constants % sfar(i)+1, constants % sfar(i+1)-1
             k = constants % far(j)
             c1 = constants % cnode(:, k)
             r1 = constants % rnode(k)
-            c1 = c - c1
-            call fmm_m2l_rotation_adj(c1, r, r1, params % pl, params % pm, &
+            c1 = c1 - c
+            call fmm_m2l_rotation_adj(c1, r1, r, params % pl, params % pm, &
                 & constants % vscales, constants % m2l_ztranslate_adj_coef, one, &
-                & node_l(:, i), one, node_m(:, k))
+                & node_l(:, k), one, node_m(:, i))
         end do
     end do
 end subroutine tree_m2l_rotation_adj

--- a/src/ddx_driver.f90
+++ b/src/ddx_driver.f90
@@ -298,7 +298,12 @@ if (ddx_data % params % model .eq. 3) then
             & state % x_lpb_rel_diff(i)
     end do
     ! Print number of iterations and time
-    write(6, 100) "ddlpb step time: ", state % x_lpb_time, " seconds"
+    write(6, 100) "ddlpb step time: ", state % x_lpb_time, &
+        & " seconds, of which:"
+    write(6, 100) "    ddcosmo: ", state % xs_time, " seconds"
+    write(6, 100) "    hsp: ", state % hsp_time, " seconds"
+    write(6, 100) "    coupling terms: ", state % x_lpb_time &
+        & - state % xs_time - state % hsp_time, " seconds"
     write(6, 300) "ddlpb step iterations: ", state % x_lpb_niter
 end if
 
@@ -348,7 +353,11 @@ if (ddx_data % params % force .eq. 1) then
         end do
         ! Print number of iterations and time
         write(6, 100) "adjoint ddlpb step time: ", &
-            & state % x_adj_lpb_time, " seconds"
+            & state % x_adj_lpb_time, " seconds, of which:"
+        write(6, 100) "    adjoint ddcosmo: ", state % s_time, " seconds"
+        write(6, 100) "    adjoint hsp: ", state % hsp_adj_time, " seconds"
+        write(6, 100) "    adjoint coupling terms: ", state % x_adj_lpb_time &
+            & - state % s_time - state % hsp_adj_time, " seconds"
         write(6, 200) "adjoint ddlpb step iterations: ", &
             & state % x_adj_lpb_niter
     end if

--- a/src/ddx_lpb.f90
+++ b/src/ddx_lpb.f90
@@ -280,7 +280,6 @@ subroutine ddlpb_solve_adjoint(params, constants, workspace, state, tol)
     real(dp) :: start_time
 
     state % x_adj_lpb_niter = params % maxiter
-    constants % inner_tol = sqrt(tol)
     workspace % s_time = zero
     workspace % hsp_adj_time = zero
 

--- a/src/ddx_lpb.f90
+++ b/src/ddx_lpb.f90
@@ -233,6 +233,8 @@ subroutine ddlpb_solve(params, constants, workspace, state, tol)
     real(dp) :: start_time
 
     state % x_lpb_niter = params % maxiter
+    workspace % xs_time = zero
+    workspace % hsp_time = zero
 
     ! solve LS using Jacobi/DIIS
     start_time = omp_get_wtime()
@@ -251,6 +253,10 @@ subroutine ddlpb_solve(params, constants, workspace, state, tol)
     ! the density so that it is consistent with the ddCOSMO and ddPCM
     ! ones.
     call convert_ddcosmo(params, constants, -1, state % x_lpb(:,:,1))
+
+    ! put the timings in the right places
+    state % xs_time = workspace % xs_time
+    state % hsp_time = workspace % hsp_time
 end subroutine ddlpb_solve
 
 
@@ -275,6 +281,8 @@ subroutine ddlpb_solve_adjoint(params, constants, workspace, state, tol)
 
     state % x_adj_lpb_niter = params % maxiter
     constants % inner_tol = sqrt(tol)
+    workspace % s_time = zero
+    workspace % hsp_adj_time = zero
 
     ! solve adjoint LS using Jacobi/DIIS
     start_time = omp_get_wtime()
@@ -290,6 +298,10 @@ subroutine ddlpb_solve_adjoint(params, constants, workspace, state, tol)
     state % x_adj_lpb_time = omp_get_wtime() - start_time
 
     state % q = state % x_adj_lpb(:, :, 1)
+
+    ! put the timings in the right places
+    state % s_time = workspace % s_time
+    state % hsp_adj_time = workspace % hsp_adj_time
 
     call ddlpb_derivative_setup(params, constants, workspace, state)
 

--- a/src/ddx_operators.f90
+++ b/src/ddx_operators.f90
@@ -1362,13 +1362,13 @@ subroutine prec_tstarx(params, constants, workspace, x, y)
     real(dp), dimension(params % maxiter) :: x_rel_diff
     real(dp) :: start_time
 
-
     start_time = omp_get_wtime()
     y(:,:,1) = x(:,:,1)
     call convert_ddcosmo(params, constants, 1, y(:,:,1))
     n_iter = params % maxiter
-    call jacobi_diis(params, constants, workspace, constants % inner_tol, y(:,:,1), &
-        & workspace % ddcosmo_guess, n_iter, x_rel_diff, lstarx, ldm1x, hnorm)
+    call jacobi_diis(params, constants, workspace, constants % inner_tol, &
+        & y(:,:,1), workspace % ddcosmo_guess, n_iter, x_rel_diff, lstarx, &
+        & ldm1x, hnorm)
     if (workspace % error_flag.ne.0) then
         workspace % error_message = 'prec_tstarx: ddCOSMO failed to converge'
         return
@@ -1378,14 +1378,16 @@ subroutine prec_tstarx(params, constants, workspace, x, y)
 
     start_time = omp_get_wtime()
     n_iter = params % maxiter
-    call jacobi_diis(params, constants, workspace, constants % inner_tol, x(:,:,2), workspace % hsp_guess, &
-        & n_iter, x_rel_diff, bstarx, bx_prec, hnorm)
+    call jacobi_diis(params, constants, workspace, constants % inner_tol, &
+        & x(:,:,2), workspace % hsp_guess, n_iter, x_rel_diff, bstarx, &
+        & bx_prec, hnorm)
     if (workspace % error_flag.ne.0) then
         workspace % error_message = 'prec_tstarx: HSP failed to converge'
         return
     end if
     y(:,:,2) = workspace % hsp_guess
-    workspace % hsp_adj_time = workspace % hsp_adj_time + omp_get_wtime() - start_time
+    workspace % hsp_adj_time = workspace % hsp_adj_time &
+        & + omp_get_wtime() - start_time
 
 end subroutine prec_tstarx
 
@@ -1409,8 +1411,9 @@ subroutine prec_tx(params, constants, workspace, x, y)
     ! perform A^-1 * Yr
     start_time = omp_get_wtime()
     n_iter = params % maxiter
-    call jacobi_diis(params, constants, workspace, constants % inner_tol, x(:,:,1), &
-        & workspace % ddcosmo_guess, n_iter, x_rel_diff, lx, ldm1x, hnorm)
+    call jacobi_diis(params, constants, workspace, constants % inner_tol, &
+        & x(:,:,1), workspace % ddcosmo_guess, n_iter, x_rel_diff, lx, &
+        & ldm1x, hnorm)
     if (workspace % error_flag.ne.0) then
         workspace % error_message = 'prec_tx: ddCOSMO failed to converge'
         return
@@ -1424,8 +1427,9 @@ subroutine prec_tx(params, constants, workspace, x, y)
     ! perform B^-1 * Ye
     start_time = omp_get_wtime()
     n_iter = params % maxiter
-    call jacobi_diis(params, constants, workspace, constants % inner_tol, x(:,:,2), workspace % hsp_guess, &
-        & n_iter, x_rel_diff, bx, bx_prec, hnorm)
+    call jacobi_diis(params, constants, workspace, constants % inner_tol, &
+        & x(:,:,2), workspace % hsp_guess, n_iter, x_rel_diff, bx, &
+        & bx_prec, hnorm)
     y(:,:,2) = workspace % hsp_guess
     workspace % hsp_time = workspace % hsp_time + omp_get_wtime() - start_time
 

--- a/src/ddx_workspace.f90
+++ b/src/ddx_workspace.f90
@@ -98,6 +98,8 @@ type ddx_workspace_type
     real(dp), allocatable :: tmp_bmat(:, :)
     !> ddLPB solutions for the microiterations
     real(dp), allocatable :: ddcosmo_guess(:,:), hsp_guess(:,:)
+    !> ddLPB temporary timings
+    real(dp) :: xs_time, s_time, hsp_time, hsp_adj_time
     !> Flag if there were an error
     integer :: error_flag = 2
     !> Last error message


### PR DESCRIPTION
Some adjoint operations in ddpcm and ddlpb were not parallelized.
Now, they have been rewritten in such a way there are no clashes between threads, and parallelized using OpenMP.

The parallelization of the L2L and M2M operations is left for later, as there is a non easily reproducible bug in the M2M operation.