### PR TITLE
Error rework

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Define common source files
 set(SRC
     ddx_definitions.f90
+    ddx_errors.f90
     ddx_parameters.f90
     ddx_constants.f90
     ddx_workspace.f90

--- a/src/ddx.f90
+++ b/src/ddx.f90
@@ -34,8 +34,10 @@ contains
 !! @param[in] tol
 !! @param[out] esolv: Solvation energy
 !! @param[out] force: Analytical forces
+!! @param[inout] error: ddX error
+!!
 subroutine ddsolve(ddx_data, state, phi_cav, e_cav, hessianphi_cav, &
-        & psi, tol, esolv, force)
+        & psi, tol, esolv, force, error)
     ! Inputs
     type(ddx_type), intent(inout) :: ddx_data
     type(ddx_state_type), intent(inout) :: state
@@ -45,23 +47,24 @@ subroutine ddsolve(ddx_data, state, phi_cav, e_cav, hessianphi_cav, &
         & psi(ddx_data % constants % nbasis, ddx_data % params % nsph), tol
     ! Outputs
     real(dp), intent(out) :: esolv, force(3, ddx_data % params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     ! Find proper model
     select case(ddx_data % params % model)
         ! COSMO model
         case (1)
             call ddcosmo(ddx_data % params, ddx_data % constants, &
                 & ddx_data % workspace, state, phi_cav, psi, &
-                & tol, esolv, force)
+                & tol, esolv, force, error)
         ! PCM model
         case (2)
             call ddpcm(ddx_data % params, ddx_data % constants, &
                 & ddx_data % workspace, state, phi_cav, psi, &
-                & tol, esolv, force)
+                & tol, esolv, force, error)
         ! LPB model
         case (3)
             call ddlpb(ddx_data % params, ddx_data % constants, &
                 & ddx_data % workspace, state, phi_cav, e_cav, &
-                & psi, tol, esolv, hessianphi_cav, force)
+                & psi, tol, esolv, hessianphi_cav, force, error)
         ! Error case
         case default
             ddx_data % params % error_flag = 1

--- a/src/ddx.f90
+++ b/src/ddx.f90
@@ -67,9 +67,8 @@ subroutine ddsolve(ddx_data, state, phi_cav, e_cav, hessianphi_cav, &
                 & psi, tol, esolv, hessianphi_cav, force, error)
         ! Error case
         case default
-            ddx_data % params % error_flag = 1
-            ddx_data % params % error_message = "unsupported solvation " // &
-                & " model in the dd solver."
+            call update_error(error, "unsupported solvation " // &
+                & " model in the dd solver.")
             return
     end select
 end subroutine ddsolve

--- a/src/ddx.h
+++ b/src/ddx.h
@@ -101,10 +101,10 @@ void* ddx_allocate_model(int model, int enable_force, double solvent_epsilon,
                          int enable_fmm, int fmm_multipole_lmax, int fmm_local_lmax,
                          int n_proc, int n_spheres, const double* sphere_centres,
                          const double* sphere_radii, int length_logfile,
-                         const char* logfile, const void* error);
+                         const char* logfile, void* error);
 
 /** Deallocate the model object */
-void ddx_deallocate_model(void* ddx, const void* error);
+void ddx_deallocate_model(void* ddx, void* error);
 
 ///@}
 
@@ -195,10 +195,10 @@ void ddx_get_cavity(const void* ddx, int ncav, double* c_ccav);
 /** \name Allocate and manage the state object */
 ///@{
 /** Allocate an empty state from a model */
-void* ddx_allocate_state(const void* ddx, const void* error);
+void* ddx_allocate_state(const void* ddx, void* error);
 
 /** Deallocate a state object */
-void ddx_deallocate_state(void* state, const void* error);
+void ddx_deallocate_state(void* state, void* error);
 
 /** Get the solution of the forward problem stored inside the state
  *  as a (nbasis, nsph) array in column-major ordering.
@@ -265,31 +265,31 @@ void ddx_get_zeta_dip(const void* state, const void* ddx, int ncav, double* zeta
  *  \param phi_cav Phi array adjoint (ncav, )-shaped array
  */
 void ddx_cosmo_setup(const void* ddx, void* state, int ncav, int nbasis, int nsph,
-                     const double* psi, const double* phi_cav, const void* error);
+                     const double* psi, const double* phi_cav, void* error);
 
 /** In-place adjust the guess inside the state, getting ready to solve a COSMO problem.
  *  Avoid calling this step if you want to use the currently stored solution as an
  * initial guess */
-void ddx_cosmo_guess(const void* ddx, void* state, const void* error);
+void ddx_cosmo_guess(const void* ddx, void* state, void* error);
 
 /** In-place adjust the guess inside the state, getting ready to solve an adjoint COSMO
  *  problem. Avoid calling this step if you want to use the currently stored solution as
  *  an initial guess */
-void ddx_cosmo_guess_adjoint(const void* ddx, void* state, const void* error);
+void ddx_cosmo_guess_adjoint(const void* ddx, void* state, void* error);
 
 /** Solve the COSMO problem.
  *  \param state   DDX state
  *  \param ddx     DDX model
  *  \param tol Tolerance up to which the problem is solved
  *  \param error   DDX error */
-void ddx_cosmo_solve(const void* ddx, void* state, double tol, const void* error);
+void ddx_cosmo_solve(const void* ddx, void* state, double tol, void* error);
 
 /** Solve the adjoint COSMO problem.
  *  \param state   DDX state
  *  \param ddx     DDX model
  *  \param tol Tolerance up to which the problem is solved
  *  \param error   DDX error */
-void ddx_cosmo_solve_adjoint(const void* ddx, void* state, double tol, const void* error);
+void ddx_cosmo_solve_adjoint(const void* ddx, void* state, double tol, void* error);
 
 /** Compute COSMO energy (without any scaling by (epsilon - 1) / epsilon
  *  or similar).
@@ -297,7 +297,7 @@ void ddx_cosmo_solve_adjoint(const void* ddx, void* state, double tol, const voi
  *  \param ddx     DDX model
  *  \param error   DDX ERROR
  */
-double ddx_cosmo_energy(const void* ddx, void* state, const void* error);
+double ddx_cosmo_energy(const void* ddx, void* state, void* error);
 
 /** Compute the COSMO force terms.
  *  \param ddx     DDX model
@@ -307,7 +307,7 @@ double ddx_cosmo_energy(const void* ddx, void* state, const void* error);
  *  \param error   DDX error
  */
 void ddx_cosmo_solvation_force_terms(const void* ddx, void* state, int nsph,
-                                     double* forces, const void* error);
+                                     double* forces, void* error);
 
 /** Setup a PCM problem in the passed state.
  *  \param ddx     DDX model
@@ -320,37 +320,37 @@ void ddx_cosmo_solvation_force_terms(const void* ddx, void* state, int nsph,
  *  \param error   DDX error
  */
 void ddx_pcm_setup(const void* ddx, void* state, int ncav, int nbasis, int nsph,
-                   const double* psi, const double* phi_cav, const void* error);
+                   const double* psi, const double* phi_cav, void* error);
 
 /** In-place adjust the guess inside the state, getting ready to solve a PCM problem.
  *  Avoid calling this step if you want to use the currently stored solution as an
  * initial guess */
-void ddx_pcm_guess(const void* ddx, void* state, const void* error);
+void ddx_pcm_guess(const void* ddx, void* state, void* error);
 
 /** In-place adjust the guess inside the state, getting ready to solve an adjoint PCM
  *  problem. Avoid calling this step if you want to use the currently stored solution as
  *  an initial guess */
-void ddx_pcm_guess_adjoint(const void* ddx, void* state, const void* error);
+void ddx_pcm_guess_adjoint(const void* ddx, void* state, void* error);
 
 /** Solve the forward PCM problem.
  *  \param state   DDX state
  *  \param ddx     DDX model
  *  \param error   DDX error
  *  \param tol Tolerance up to which the problem is solved */
-void ddx_pcm_solve(const void* ddx, void* state, double tol, const void* error);
+void ddx_pcm_solve(const void* ddx, void* state, double tol, void* error);
 
 /** Solve the adjoint PCM problem.
  *  \param state   DDX state
  *  \param ddx     DDX model
  *  \param error   DDX error
  *  \param tol Tolerance up to which the problem is solved */
-void ddx_pcm_solve_adjoint(const void* ddx, void* state, double tol, const void* error);
+void ddx_pcm_solve_adjoint(const void* ddx, void* state, double tol, void* error);
 
 /** Compute PCM energy
  *  \param state   DDX state
  *  \param error   DDX error
  *  \param ddx     DDX model */
-double ddx_pcm_energy(const void* ddx, void* state, const void* error);
+double ddx_pcm_energy(const void* ddx, void* state, void* error);
 
 /** Compute the PCM force terms.
  *  \param ddx     DDX model
@@ -360,7 +360,7 @@ double ddx_pcm_energy(const void* ddx, void* state, const void* error);
  *  \param error   DDX error
  */
 void ddx_pcm_solvation_force_terms(const void* ddx, void* state, int nsph,
-                                   double* forces, const void* error);
+                                   double* forces, void* error);
 
 // TODO LPB
 
@@ -378,39 +378,39 @@ void ddx_pcm_solvation_force_terms(const void* ddx, void* state, int nsph,
  */
 void ddx_lpb_setup(const void* ddx, void* state, int ncav, int nbasis, int nsph,
                    const double* psi, const double* phi_cav, const double* e_cav,
-                   const void* error);
+                   void* error);
 
 /** In-place adjust the guess inside the state, getting ready to solve a LPB problem.
  *  Avoid calling this step if you want to use the currently stored solution as an
  *  initial guess. tol is the tolerance for solving a simplified initial-guess problem.
  *  The same tolerance as for the ddx_lpb_solve call should be chosen. */
-void ddx_lpb_guess(const void* ddx, void* state, double tol, const void* error);
+void ddx_lpb_guess(const void* ddx, void* state, double tol, void* error);
 
 /** In-place adjust the guess inside the state, getting ready to solve an adjoint LPB
  *  problem. Avoid calling this step if you want to use the currently stored solution as
  *  an initial guess. tol is the tolerance for solving a simplified initial-guess problem.
  *  The same tolerance as for the ddx_lpb_solve call should be chosen. */
-void ddx_lpb_guess_adjoint(const void* ddx, void* state, double tol, const void* error);
+void ddx_lpb_guess_adjoint(const void* ddx, void* state, double tol, void* error);
 
 /** Solve the forward LPB problem.
  *  \param state   DDX state
  *  \param ddx     DDX model
  *  \param error   DDX error
  *  \param tol Tolerance up to which the problem is solved */
-void ddx_lpb_solve(const void* ddx, void* state, double tol, const void* error);
+void ddx_lpb_solve(const void* ddx, void* state, double tol, void* error);
 
 /** Solve the adjoint LPB problem.
  *  \param state   DDX state
  *  \param ddx     DDX model
  *  \param error   DDX error
  *  \param tol Tolerance up to which the problem is solved */
-void ddx_lpb_solve_adjoint(const void* ddx, void* state, double tol, const void* error);
+void ddx_lpb_solve_adjoint(const void* ddx, void* state, double tol, void* error);
 
 /** Compute LPB energy
  *  \param state   DDX state
  *  \param error   DDX error
  *  \param ddx     DDX model */
-double ddx_lpb_energy(const void* ddx, void* state, const void* error);
+double ddx_lpb_energy(const void* ddx, void* state, void* error);
 
 // TODO LPB force terms not yet supported in C and python interface
 
@@ -432,7 +432,7 @@ double ddx_lpb_energy(const void* ddx, void* state, const void* error);
  *  \param error   DDX error
  */
 void ddx_multipole_electrostatics_0(const void* ddx, int nsph, int ncav, int nmultipoles,
-                                    const double* multipoles, double* phi_cav, const void* error);
+                                    const double* multipoles, double* phi_cav, void* error);
 
 /** Build potential and electric field generated by a multipolar charge distribution.
  *  \param ddx      DDX model
@@ -450,7 +450,7 @@ void ddx_multipole_electrostatics_0(const void* ddx, int nsph, int ncav, int nmu
  */
 void ddx_multipole_electrostatics_1(const void* ddx, int nsph, int ncav, int nmultipoles,
                                     const double* multipoles, double* phi_cav,
-                                    double* e_cav, const void* error);
+                                    double* e_cav, void* error);
 
 /** Build potential, electric field and field gradient generated by a multipolar charge
  *  distribution.
@@ -471,7 +471,7 @@ void ddx_multipole_electrostatics_1(const void* ddx, int nsph, int ncav, int nmu
  */
 void ddx_multipole_electrostatics_2(const void* ddx, int nsph, int ncav, int nmultipoles,
                                     const double* multipoles, double* phi_cav,
-                                    double* e_cav, double* g_cav, const void* error);
+                                    double* e_cav, double* g_cav, void* error);
 
 /** Build the Psi generated by a multipolar charge distribution
  *  \param ddx     DDX model
@@ -486,7 +486,7 @@ void ddx_multipole_electrostatics_2(const void* ddx, int nsph, int ncav, int nmu
  *  \param error   DDX error
  */
 void ddx_multipole_psi(const void* ddx, int nbasis, int nsph, int nmultipoles,
-                       const double* multipoles, double* psi, const void* error);
+                       const double* multipoles, double* psi, void* error);
 
 /** Compute the force terms generated by a multipolar charge distribution
  *  \param ddx     DDX model
@@ -505,7 +505,7 @@ void ddx_multipole_psi(const void* ddx, int nbasis, int nsph, int nmultipoles,
  */
 void ddx_multipole_forces(const void* ddx, void* state, int nsph, int ncav,
                           int nmultipoles, const double* multipoles, const double* e_cav,
-                          double* forces, const void* error);
+                          double* forces, void* error);
 
 ///@}
 ///@}

--- a/src/ddx_cinterface.f90
+++ b/src/ddx_cinterface.f90
@@ -129,7 +129,7 @@ function ddx_allocate_model(model, enable_force, solvent_epsilon, solvent_kappa,
     if (ddx%constants%error_flag .ne. 0) then
         return
     endif
-    call workspace_init(ddx%params, ddx%constants, ddx%workspace)
+    call workspace_init(ddx%params, ddx%constants, ddx%workspace, ddx%error)
     if (ddx%workspace%error_flag .ne. 0) then
         return
     endif
@@ -401,7 +401,7 @@ function ddx_allocate_state(c_ddx) result(c_state) bind(C)
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
     allocate(state)
-    call ddx_init_state(ddx%params, ddx%constants, state)
+    call ddx_init_state(ddx%params, ddx%constants, state, ddx%error)
     c_state = c_loc(state)
 end function
 

--- a/src/ddx_cinterface.f90
+++ b/src/ddx_cinterface.f90
@@ -109,7 +109,7 @@ subroutine ddx_get_error_message(c_error, message, maxlen) bind(C)
     type(c_ptr), intent(in), value :: c_error
     integer(c_int), intent(in), value :: maxlen
     character(len=1, kind=C_char), intent(out) :: message(maxlen)
-    character(len=2000) :: error_message
+    character(len=2047) :: error_message
     type(ddx_error_type), pointer :: error
     integer :: length, i
     call c_f_pointer(c_error, error)

--- a/src/ddx_cinterface.f90
+++ b/src/ddx_cinterface.f90
@@ -17,7 +17,6 @@ module ddx_cinterface
         type(ddx_params_type)    :: params
         type(ddx_constants_type) :: constants
         type(ddx_workspace_type) :: workspace
-        type(ddx_error_type)     :: error
     end type ddx_setup
 
 contains
@@ -90,29 +89,73 @@ end
 !
 ! Error
 !
+
 function ddx_allocate_error() result(c_error) bind(C)
-    type(ddx_error_type), pointer :: error
     type(c_ptr) :: c_error
-    call c_f_pointer(c_error, error)
+    type(ddx_error_type), pointer :: error
+    allocate(error)
+    c_error = c_loc(error)
 end function
+
+function ddx_get_error_flag(c_error) result(has_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
+    type(ddx_error_type), pointer :: error
+    integer(c_int) :: has_error
+    call c_f_pointer(c_error, error)
+    has_error = error%flag
+end
+
+subroutine ddx_get_error_message(c_error, message, maxlen) bind(C)
+    type(c_ptr), intent(in), value :: c_error
+    integer(c_int), intent(in), value :: maxlen
+    character(len=1, kind=C_char), intent(out) :: message(maxlen)
+    character(len=2000) :: error_message
+    type(ddx_error_type), pointer :: error
+    integer :: length, i
+    call c_f_pointer(c_error, error)
+    if (error%flag .ne. 0) then
+        error_message = error%message
+    else
+        error_message = ''
+    endif
+
+    ! Convert to C message
+    message(maxlen) = c_null_char
+    length = min(maxlen-1, error%message_length-1)
+    do i = length, 1, -1
+        if (error_message(i:i) .eq. ' ') then
+            length = i-1
+        else
+            exit
+        endif
+    enddo
+    message(length + 1) = c_null_char
+    do i = 1, length
+        message(i) = error_message(i:i)
+    enddo
+end
 
 !
 ! Setup object
 !
 function ddx_allocate_model(model, enable_force, solvent_epsilon, solvent_kappa, eta, se, lmax, &
         & n_lebedev, incore, maxiter, jacobi_n_diis, enable_fmm, fmm_multipole_lmax, fmm_local_lmax, &
-        & n_proc, n_spheres, sphere_centres, sphere_radii, length_logfile, c_logfile) result(c_ddx) bind(C)
+        & n_proc, n_spheres, sphere_centres, sphere_radii, length_logfile, c_logfile, c_error) result(c_ddx) bind(C)
     integer(c_int), intent(in), value :: model, enable_force, lmax, n_lebedev, maxiter, &
         & incore, jacobi_n_diis, enable_fmm, fmm_multipole_lmax, fmm_local_lmax, n_proc, &
         & n_spheres, length_logfile
     real(c_double), intent(in) :: sphere_centres(3, n_spheres), sphere_radii(n_spheres)
     real(c_double), intent(in), value :: eta, se, solvent_epsilon, solvent_kappa
+    type(c_ptr), intent(in), value :: c_error
+    type(ddx_error_type), pointer :: error
     !type(c_funptr), value :: printfctn
     type(c_ptr) :: c_ddx
     integer :: passproc, i
     type(ddx_setup), pointer :: ddx
     character(len=1, kind=C_char), intent(in) :: c_logfile(length_logfile)
     character(len=255) :: logfile
+
+    call c_f_pointer(c_error, error)
 
     ! Allocate DDX object
     allocate(ddx)
@@ -130,66 +173,30 @@ function ddx_allocate_model(model, enable_force, solvent_epsilon, solvent_kappa,
     call params_init(model, enable_force, solvent_epsilon, solvent_kappa, eta, se, lmax, &
         & n_lebedev, incore, maxiter, jacobi_n_diis, enable_fmm, &
         & fmm_multipole_lmax, fmm_local_lmax, passproc, n_spheres, &
-        & sphere_centres, sphere_radii, logfile, ddx%params, ddx%error)
-    if (ddx%error%flag .ne. 0) then
+        & sphere_centres, sphere_radii, logfile, ddx%params, error)
+    if (error%flag .ne. 0) then
         return
     endif
-    call constants_init(ddx%params, ddx%constants, ddx%error)
-    if (ddx%error%flag .ne. 0) then
+    call constants_init(ddx%params, ddx%constants, error)
+    if (error%flag .ne. 0) then
         return
     endif
-    call workspace_init(ddx%params, ddx%constants, ddx%workspace, ddx%error)
-    if (ddx%error%flag .ne. 0) then
+    call workspace_init(ddx%params, ddx%constants, ddx%workspace, error)
+    if (error%flag .ne. 0) then
         return
     endif
 end function
 
-subroutine ddx_deallocate_model(c_ddx) bind(C)
-    type(c_ptr), intent(in), value :: c_ddx
+subroutine ddx_deallocate_model(c_ddx, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_ddx, c_error
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     call c_f_pointer(c_ddx, ddx)
-    call params_free(ddx%params, ddx%error)
-    call constants_free(ddx%constants, ddx%error)
-    call workspace_free(ddx%workspace, ddx%error)
+    call c_f_pointer(c_error, error)
+    call params_free(ddx%params, error)
+    call constants_free(ddx%constants, error)
+    call workspace_free(ddx%workspace, error)
     deallocate(ddx)
-end
-
-function ddx_get_error_flag(c_ddx) result(has_error) bind(C)
-    type(c_ptr), intent(in), value :: c_ddx
-    type(ddx_setup), pointer :: ddx
-    integer(c_int) :: has_error
-    call c_f_pointer(c_ddx, ddx)
-    has_error = ddx%error%flag
-end
-
-subroutine ddx_get_error_message(c_ddx, message, maxlen) bind(C)
-    type(c_ptr), intent(in), value :: c_ddx
-    integer(c_int), intent(in), value :: maxlen
-    character(len=1, kind=C_char), intent(out) :: message(maxlen)
-    character(len=255) :: error_message
-    type(ddx_setup), pointer :: ddx
-    integer :: length, i
-    call c_f_pointer(c_ddx, ddx)
-    if (ddx%error%flag .ne. 0) then
-        error_message = ddx%error%message
-    else
-        error_message = ''
-    endif
-
-    ! Convert to C message
-    message(maxlen) = c_null_char
-    length = min(maxlen-1, 255)
-    do i = length, 1, -1
-        if (error_message(i:i) .eq. ' ') then
-            length = i-1
-        else
-            exit
-        endif
-    enddo
-    message(length + 1) = c_null_char
-    do i = 1, length
-        message(i) = error_message(i:i)
-    enddo
 end
 
 subroutine ddx_get_logfile(c_ddx, message, maxlen) bind(C)
@@ -391,64 +398,28 @@ end subroutine
 !
 ! State object
 !
-function ddx_allocate_state(c_ddx) result(c_state) bind(C)
-    type(c_ptr), intent(in), value :: c_ddx
+function ddx_allocate_state(c_ddx, c_error) result(c_state) bind(C)
+    type(c_ptr), intent(in), value :: c_ddx, c_error
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(c_ptr) :: c_state
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     allocate(state)
-    call ddx_init_state(ddx%params, ddx%constants, state, ddx%error)
+    call ddx_init_state(ddx%params, ddx%constants, state, error)
     c_state = c_loc(state)
 end function
 
-subroutine ddx_deallocate_state(c_state) bind(C)
-    type(c_ptr), intent(in), value :: c_state
+subroutine ddx_deallocate_state(c_state, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_state, c_error
     type(ddx_state_type), pointer :: state
-    type(ddx_error_type) :: error
+    type(ddx_error_type), pointer :: error
     call c_f_pointer(c_state, state)
+    call c_f_pointer(c_error, error)
     call ddx_free_state(state, error)
     deallocate(state)
 end subroutine
-
-function ddx_get_state_error_flag(c_state) result(has_error) bind(C)
-    type(c_ptr), intent(in), value :: c_state
-    type(ddx_state_type), pointer :: state
-    integer(c_int) :: has_error
-    call c_f_pointer(c_state, state)
-    has_error = state%error_flag
-end
-
-subroutine ddx_get_state_error_message(c_state, message, maxlen) bind(C)
-    type(c_ptr), intent(in), value :: c_state
-    type(ddx_state_type), pointer :: state
-    integer(c_int), intent(in), value :: maxlen
-    character(len=1, kind=C_char), intent(out) :: message(maxlen)
-    character(len=255) :: error_message
-    integer :: length, i
-    call c_f_pointer(c_state, state)
-
-    if (state%error_flag .ne. 0) then
-        error_message = state%error_message
-    else
-        error_message = ''
-    endif
-
-    ! Convert to C message
-    message(maxlen) = c_null_char
-    length = min(maxlen-1, 255)
-    do i = length, 1, -1
-        if (error_message(i:i) .eq. ' ') then
-            length = i-1
-        else
-            exit
-        endif
-    enddo
-    message(length + 1) = c_null_char
-    do i = 1, length
-        message(i) = error_message(i:i)
-    enddo
-end
 
 subroutine ddx_get_x(c_state, nbasis, nsph, x) bind(C)
     type(c_ptr), intent(in), value :: c_state
@@ -531,78 +502,99 @@ end subroutine
 ! Cosmo
 !
 ! Setup the problem in the state
-subroutine ddx_cosmo_setup(c_ddx, c_state, ncav, nbasis, nsph, psi, phi_cav) bind(C)
+subroutine ddx_cosmo_setup(c_ddx, c_state, ncav, nbasis, nsph, psi, phi_cav, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     integer(c_int), intent(in), value :: ncav, nbasis, nsph
     real(c_double), intent(in) :: phi_cav(ncav), psi(nbasis, nsph)
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
     call ddcosmo_setup(ddx%params, ddx%constants, ddx%workspace, state, phi_cav, psi)
 end subroutine
 
 ! Put a guess for the problem into the state (optional)
-subroutine ddx_cosmo_guess(c_ddx, c_state) bind(C)
+subroutine ddx_cosmo_guess(c_ddx, c_state, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddcosmo_guess(ddx%params, ddx%constants, ddx%workspace, state, ddx%error)
+    call ddcosmo_guess(ddx%params, ddx%constants, ddx%workspace, state, error)
 end
 
 ! Solve the problem
-subroutine ddx_cosmo_solve(c_ddx, c_state, tol) bind(C)
+subroutine ddx_cosmo_solve(c_ddx, c_state, tol, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddcosmo_solve(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
+    call ddcosmo_solve(ddx%params, ddx%constants, ddx%workspace, state, tol, error)
 end subroutine
 
 ! Put a guess for the adjoint problem into the state (optional)
-subroutine ddx_cosmo_guess_adjoint(c_ddx, c_state) bind(C)
+subroutine ddx_cosmo_guess_adjoint(c_ddx, c_state, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddcosmo_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, ddx%error)
+    call ddcosmo_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, error)
 end
 
 ! Solve the adjoint problem inside the state
-subroutine ddx_cosmo_solve_adjoint(c_ddx, c_state, tol) bind(C)
+subroutine ddx_cosmo_solve_adjoint(c_ddx, c_state, tol, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddcosmo_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
+    call ddcosmo_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, error)
 end
 
 ! Compute the ddCOSMO energy
-function ddx_cosmo_energy(c_ddx, c_state) result(c_energy) bind(C)
+function ddx_cosmo_energy(c_ddx, c_state, c_error) result(c_energy) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     real(c_double) :: c_energy
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
     call ddcosmo_energy(ddx%constants, state, c_energy)
 end function
 
 ! Compute the forces
-subroutine ddx_cosmo_solvation_force_terms(c_ddx, c_state, nsph, forces) bind(C)
+subroutine ddx_cosmo_solvation_force_terms(c_ddx, c_state, nsph, forces, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     integer(c_int), intent(in), value :: nsph
     real(c_double), intent(out) :: forces(3, nsph)
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
     call ddcosmo_solvation_force_terms(ddx%params, ddx%constants, ddx%workspace, state, forces)
 end
@@ -610,72 +602,93 @@ end
 !
 ! PCM
 !
-subroutine ddx_pcm_setup(c_ddx, c_state, ncav, nbasis, nsph, psi, phi_cav) bind(C)
+subroutine ddx_pcm_setup(c_ddx, c_state, ncav, nbasis, nsph, psi, phi_cav, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     integer(c_int), intent(in), value :: ncav, nbasis, nsph
     real(c_double), intent(in) :: phi_cav(ncav), psi(nbasis, nsph)
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
     call ddpcm_setup(ddx%params, ddx%constants, ddx%workspace, state, phi_cav, psi)
 end subroutine
 
-subroutine ddx_pcm_guess(c_ddx, c_state) bind(C)
+subroutine ddx_pcm_guess(c_ddx, c_state, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddpcm_guess(ddx%params, ddx%constants, ddx%workspace, state, ddx%error)
+    call ddpcm_guess(ddx%params, ddx%constants, ddx%workspace, state, error)
 end
 
-subroutine ddx_pcm_solve(c_ddx, c_state, tol) bind(C)
+subroutine ddx_pcm_solve(c_ddx, c_state, tol, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddpcm_solve(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
+    call ddpcm_solve(ddx%params, ddx%constants, ddx%workspace, state, tol, error)
 end subroutine
 
-subroutine ddx_pcm_guess_adjoint(c_ddx, c_state) bind(C)
+subroutine ddx_pcm_guess_adjoint(c_ddx, c_state, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddpcm_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, ddx%error)
+    call ddpcm_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, error)
 end
 
-subroutine ddx_pcm_solve_adjoint(c_ddx, c_state, tol) bind(C)
+subroutine ddx_pcm_solve_adjoint(c_ddx, c_state, tol, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddpcm_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
+    call ddpcm_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, error)
 end
 
-function ddx_pcm_energy(c_ddx, c_state) result(c_energy) bind(C)
+function ddx_pcm_energy(c_ddx, c_state, c_error) result(c_energy) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     real(c_double) :: c_energy
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
     call ddpcm_energy(ddx%constants, state, c_energy)
 end function
 
-subroutine ddx_pcm_solvation_force_terms(c_ddx, c_state, nsph, forces) bind(C)
+subroutine ddx_pcm_solvation_force_terms(c_ddx, c_state, nsph, forces, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     integer(c_int), intent(in), value :: nsph
     real(c_double), intent(out) :: forces(3, nsph)
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
     call ddpcm_solvation_force_terms(ddx%params, ddx%constants, ddx%workspace, state, forces)
 end
@@ -683,63 +696,81 @@ end
 !
 ! LPB
 !
-subroutine ddx_lpb_setup(c_ddx, c_state, ncav, nbasis, nsph, psi, phi_cav, gradphi_cav) bind(C)
+subroutine ddx_lpb_setup(c_ddx, c_state, ncav, nbasis, nsph, psi, phi_cav, gradphi_cav, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     integer(c_int), intent(in), value :: ncav, nbasis, nsph
     real(c_double), intent(in) :: phi_cav(ncav), psi(nbasis, nsph), gradphi_cav(3, ncav)
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddlpb_setup(ddx%params, ddx%constants, ddx%workspace, state, phi_cav, gradphi_cav, psi, ddx%error)
+    call ddlpb_setup(ddx%params, ddx%constants, ddx%workspace, state, phi_cav, gradphi_cav, psi, error)
 end subroutine
 
-subroutine ddx_lpb_guess(c_ddx, c_state, tol) bind(C)
+subroutine ddx_lpb_guess(c_ddx, c_state, tol, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     real(c_double), intent(in), value :: tol
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddlpb_guess(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
+    call ddlpb_guess(ddx%params, ddx%constants, ddx%workspace, state, tol, error)
 end
 
-subroutine ddx_lpb_solve(c_ddx, c_state, tol) bind(C)
+subroutine ddx_lpb_solve(c_ddx, c_state, tol, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddlpb_solve(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
+    call ddlpb_solve(ddx%params, ddx%constants, ddx%workspace, state, tol, error)
 end subroutine
 
-subroutine ddx_lpb_guess_adjoint(c_ddx, c_state, tol) bind(C)
+subroutine ddx_lpb_guess_adjoint(c_ddx, c_state, tol, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     real(c_double), intent(in), value :: tol
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddlpb_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
+    call ddlpb_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, error)
 end
 
-subroutine ddx_lpb_solve_adjoint(c_ddx, c_state, tol) bind(C)
+subroutine ddx_lpb_solve_adjoint(c_ddx, c_state, tol, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddlpb_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
+    call ddlpb_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, error)
 end
 
-function ddx_lpb_energy(c_ddx, c_state) result(c_energy) bind(C)
+function ddx_lpb_energy(c_ddx, c_state, c_error) result(c_energy) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     real(c_double) :: c_energy
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
     call ddlpb_energy(ddx%constants, state, c_energy)
 end function
@@ -751,63 +782,77 @@ end function
 ! multipolar solutes
 !
 subroutine ddx_multipole_electrostatics_0(c_ddx, nsph, ncav, nmultipoles, multipoles, &
-        & phi_cav) bind(C)
+        & phi_cav, c_error) bind(C)
     type(c_ptr), intent(in), value :: c_ddx
     type(ddx_setup), pointer :: ddx
     integer(c_int), intent(in), value :: nsph, ncav, nmultipoles
     real(c_double), intent(in) :: multipoles(nmultipoles, nsph)
     real(c_double), intent(out) :: phi_cav(ncav)
+    type(c_ptr), intent(in), value :: c_error
+    type(ddx_error_type), pointer :: error
     integer :: mmax
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_ddx, ddx)
     mmax = int(sqrt(dble(nmultipoles)) - 1d0)
     call build_phi(ddx%params, ddx%constants, ddx%workspace, multipoles, mmax, &
-            & phi_cav, ddx%error)
+            & phi_cav, error)
 end
 
 subroutine ddx_multipole_electrostatics_1(c_ddx, nsph, ncav, nmultipoles, multipoles, &
-        & phi_cav, e_cav) bind(C)
+        & phi_cav, e_cav, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     integer(c_int), intent(in), value :: nsph, ncav, nmultipoles
     real(c_double), intent(in) :: multipoles(nmultipoles, nsph)
     real(c_double), intent(out) :: phi_cav(ncav), e_cav(3, ncav)
     integer :: mmax
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     mmax = int(sqrt(dble(nmultipoles)) - 1d0)
     call build_e(ddx%params, ddx%constants, ddx%workspace, multipoles, mmax, &
-            & phi_cav, e_cav, ddx%error)
+            & phi_cav, e_cav, error)
 end
 
 subroutine ddx_multipole_electrostatics_2(c_ddx, nsph, ncav, nmultipoles, multipoles, &
-        & phi_cav, e_cav, g_cav) bind(C)
+        & phi_cav, e_cav, g_cav, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     integer(c_int), intent(in), value :: nsph, ncav, nmultipoles
     real(c_double), intent(in) :: multipoles(nmultipoles, nsph)
     real(c_double), intent(out) :: phi_cav(ncav), e_cav(3, ncav), g_cav(3, 3, ncav)
     integer :: mmax
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     mmax = int(sqrt(dble(nmultipoles)) - 1d0)
     call build_g(ddx%params, ddx%constants, ddx%workspace, multipoles, mmax, &
-            & phi_cav, e_cav, g_cav, ddx%error)
+            & phi_cav, e_cav, g_cav, error)
 end
 
-subroutine ddx_multipole_psi(c_ddx, nbasis, nsph, nmultipoles, multipoles, psi) bind(C)
+subroutine ddx_multipole_psi(c_ddx, nbasis, nsph, nmultipoles, multipoles, psi, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     integer(c_int), intent(in), value :: nmultipoles, nsph, nbasis
     real(c_double), intent(in) :: multipoles(nmultipoles, nsph)
     real(c_double), intent(out) :: psi(nbasis, nsph)
     integer :: mmax
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     mmax = int(sqrt(dble(nmultipoles)) - 1d0)
     call build_psi(ddx%params, multipoles, mmax, psi)
 end
 
 subroutine ddx_multipole_forces(c_ddx, c_state, nsph, ncav, nmultipoles, multipoles, &
-                & e_cav, forces) bind(C)
+                & e_cav, forces, c_error) bind(C)
+    type(c_ptr), intent(in), value :: c_error
     type(c_ptr), intent(in), value :: c_ddx, c_state
     type(ddx_setup), pointer :: ddx
+    type(ddx_error_type), pointer :: error
     type(ddx_state_type), pointer :: state
     integer(c_int), intent(in), value :: nmultipoles, nsph, ncav
     integer :: mmax
@@ -815,10 +860,11 @@ subroutine ddx_multipole_forces(c_ddx, c_state, nsph, ncav, nmultipoles, multipo
         & e_cav(3, ncav)
     real(c_double), intent(out) :: forces(3, nsph)
     call c_f_pointer(c_ddx, ddx)
+    call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
     mmax = int(sqrt(dble(nmultipoles)) - 1d0)
     call grad_phi(ddx%params, ddx%constants, ddx%workspace, state, mmax, &
-        & multipoles, forces, e_cav, ddx%error)
+        & multipoles, forces, e_cav, error)
 end
 
 end

--- a/src/ddx_cinterface.f90
+++ b/src/ddx_cinterface.f90
@@ -529,7 +529,6 @@ subroutine ddx_get_zeta_dip(c_state, c_ddx, ncav, zeta_dip) bind(C)
     endif
 end subroutine
 
-
 !
 ! Cosmo
 !

--- a/src/ddx_cinterface.f90
+++ b/src/ddx_cinterface.f90
@@ -2,6 +2,7 @@ module ddx_cinterface
     use, intrinsic :: iso_c_binding
     use ddx_core
     use ddx_definitions
+    use ddx_errors
     use ddx_constants
     use ddx_parameters
     use ddx_workspace
@@ -16,6 +17,7 @@ module ddx_cinterface
         type(ddx_params_type)    :: params
         type(ddx_constants_type) :: constants
         type(ddx_workspace_type) :: workspace
+        type(ddx_error_type) :: error
     end type ddx_setup
 
 contains
@@ -119,11 +121,11 @@ function ddx_allocate_model(model, enable_force, solvent_epsilon, solvent_kappa,
     call params_init(model, enable_force, solvent_epsilon, solvent_kappa, eta, se, lmax, &
         & n_lebedev, incore, maxiter, jacobi_n_diis, enable_fmm, &
         & fmm_multipole_lmax, fmm_local_lmax, passproc, n_spheres, &
-        & sphere_centres, sphere_radii, logfile, ddx%params)
+        & sphere_centres, sphere_radii, logfile, ddx%params, ddx%error)
     if (ddx%params%error_flag .ne. 0) then
         return
     endif
-    call constants_init(ddx%params, ddx%constants)
+    call constants_init(ddx%params, ddx%constants, ddx%error)
     if (ddx%constants%error_flag .ne. 0) then
         return
     endif

--- a/src/ddx_cinterface.f90
+++ b/src/ddx_cinterface.f90
@@ -552,7 +552,7 @@ subroutine ddx_cosmo_guess(c_ddx, c_state) bind(C)
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddcosmo_guess(ddx%params, ddx%constants, ddx%workspace, state)
+    call ddcosmo_guess(ddx%params, ddx%constants, ddx%workspace, state, ddx%error)
 end
 
 ! Solve the problem
@@ -563,7 +563,7 @@ subroutine ddx_cosmo_solve(c_ddx, c_state, tol) bind(C)
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddcosmo_solve(ddx%params, ddx%constants, ddx%workspace, state, tol)
+    call ddcosmo_solve(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
 end subroutine
 
 ! Put a guess for the adjoint problem into the state (optional)
@@ -573,7 +573,7 @@ subroutine ddx_cosmo_guess_adjoint(c_ddx, c_state) bind(C)
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddcosmo_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state)
+    call ddcosmo_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, ddx%error)
 end
 
 ! Solve the adjoint problem inside the state
@@ -584,7 +584,7 @@ subroutine ddx_cosmo_solve_adjoint(c_ddx, c_state, tol) bind(C)
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddcosmo_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol)
+    call ddcosmo_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
 end
 
 ! Compute the ddCOSMO energy
@@ -630,7 +630,7 @@ subroutine ddx_pcm_guess(c_ddx, c_state) bind(C)
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddpcm_guess(ddx%params, ddx%constants, ddx%workspace, state)
+    call ddpcm_guess(ddx%params, ddx%constants, ddx%workspace, state, ddx%error)
 end
 
 subroutine ddx_pcm_solve(c_ddx, c_state, tol) bind(C)
@@ -640,7 +640,7 @@ subroutine ddx_pcm_solve(c_ddx, c_state, tol) bind(C)
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddpcm_solve(ddx%params, ddx%constants, ddx%workspace, state, tol)
+    call ddpcm_solve(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
 end subroutine
 
 subroutine ddx_pcm_guess_adjoint(c_ddx, c_state) bind(C)
@@ -649,7 +649,7 @@ subroutine ddx_pcm_guess_adjoint(c_ddx, c_state) bind(C)
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddpcm_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state)
+    call ddpcm_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, ddx%error)
 end
 
 subroutine ddx_pcm_solve_adjoint(c_ddx, c_state, tol) bind(C)
@@ -659,7 +659,7 @@ subroutine ddx_pcm_solve_adjoint(c_ddx, c_state, tol) bind(C)
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddpcm_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol)
+    call ddpcm_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
 end
 
 function ddx_pcm_energy(c_ddx, c_state) result(c_energy) bind(C)
@@ -704,7 +704,7 @@ subroutine ddx_lpb_guess(c_ddx, c_state, tol) bind(C)
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddlpb_guess(ddx%params, ddx%constants, ddx%workspace, state, tol)
+    call ddlpb_guess(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
 end
 
 subroutine ddx_lpb_solve(c_ddx, c_state, tol) bind(C)
@@ -714,7 +714,7 @@ subroutine ddx_lpb_solve(c_ddx, c_state, tol) bind(C)
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddlpb_solve(ddx%params, ddx%constants, ddx%workspace, state, tol)
+    call ddlpb_solve(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
 end subroutine
 
 subroutine ddx_lpb_guess_adjoint(c_ddx, c_state, tol) bind(C)
@@ -724,7 +724,7 @@ subroutine ddx_lpb_guess_adjoint(c_ddx, c_state, tol) bind(C)
     type(ddx_state_type), pointer :: state
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddlpb_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol)
+    call ddlpb_guess_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
 end
 
 subroutine ddx_lpb_solve_adjoint(c_ddx, c_state, tol) bind(C)
@@ -734,7 +734,7 @@ subroutine ddx_lpb_solve_adjoint(c_ddx, c_state, tol) bind(C)
     real(c_double), intent(in), value :: tol
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_state, state)
-    call ddlpb_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol)
+    call ddlpb_solve_adjoint(ddx%params, ddx%constants, ddx%workspace, state, tol, ddx%error)
 end
 
 function ddx_lpb_energy(c_ddx, c_state) result(c_energy) bind(C)

--- a/src/ddx_cinterface.f90
+++ b/src/ddx_cinterface.f90
@@ -513,7 +513,7 @@ subroutine ddx_cosmo_setup(c_ddx, c_state, ncav, nbasis, nsph, psi, phi_cav, c_e
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddcosmo_setup(ddx%params, ddx%constants, ddx%workspace, state, phi_cav, psi)
+    call ddcosmo_setup(ddx%params, ddx%constants, ddx%workspace, state, phi_cav, psi, error)
 end subroutine
 
 ! Put a guess for the problem into the state (optional)
@@ -581,7 +581,7 @@ function ddx_cosmo_energy(c_ddx, c_state, c_error) result(c_energy) bind(C)
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddcosmo_energy(ddx%constants, state, c_energy)
+    call ddcosmo_energy(ddx%constants, state, c_energy, error)
 end function
 
 ! Compute the forces
@@ -596,7 +596,7 @@ subroutine ddx_cosmo_solvation_force_terms(c_ddx, c_state, nsph, forces, c_error
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddcosmo_solvation_force_terms(ddx%params, ddx%constants, ddx%workspace, state, forces)
+    call ddcosmo_solvation_force_terms(ddx%params, ddx%constants, ddx%workspace, state, forces, error)
 end
 
 !
@@ -613,7 +613,7 @@ subroutine ddx_pcm_setup(c_ddx, c_state, ncav, nbasis, nsph, psi, phi_cav, c_err
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddpcm_setup(ddx%params, ddx%constants, ddx%workspace, state, phi_cav, psi)
+    call ddpcm_setup(ddx%params, ddx%constants, ddx%workspace, state, phi_cav, psi, error)
 end subroutine
 
 subroutine ddx_pcm_guess(c_ddx, c_state, c_error) bind(C)
@@ -676,7 +676,7 @@ function ddx_pcm_energy(c_ddx, c_state, c_error) result(c_energy) bind(C)
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddpcm_energy(ddx%constants, state, c_energy)
+    call ddpcm_energy(ddx%constants, state, c_energy, error)
 end function
 
 subroutine ddx_pcm_solvation_force_terms(c_ddx, c_state, nsph, forces, c_error) bind(C)
@@ -690,7 +690,7 @@ subroutine ddx_pcm_solvation_force_terms(c_ddx, c_state, nsph, forces, c_error) 
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddpcm_solvation_force_terms(ddx%params, ddx%constants, ddx%workspace, state, forces)
+    call ddpcm_solvation_force_terms(ddx%params, ddx%constants, ddx%workspace, state, forces, error)
 end
 
 !
@@ -772,7 +772,7 @@ function ddx_lpb_energy(c_ddx, c_state, c_error) result(c_energy) bind(C)
     call c_f_pointer(c_ddx, ddx)
     call c_f_pointer(c_error, error)
     call c_f_pointer(c_state, state)
-    call ddlpb_energy(ddx%constants, state, c_energy)
+    call ddlpb_energy(ddx%constants, state, c_energy, error)
 end function
 
 ! TODO LPB force terms not yet supported in C and python interface

--- a/src/ddx_cinterface.f90
+++ b/src/ddx_cinterface.f90
@@ -764,7 +764,7 @@ subroutine ddx_multipole_electrostatics_0(c_ddx, nsph, ncav, nmultipoles, multip
     call c_f_pointer(c_ddx, ddx)
     mmax = int(sqrt(dble(nmultipoles)) - 1d0)
     call build_phi(ddx%params, ddx%constants, ddx%workspace, multipoles, mmax, &
-            & phi_cav)
+            & phi_cav, ddx%error)
 end
 
 subroutine ddx_multipole_electrostatics_1(c_ddx, nsph, ncav, nmultipoles, multipoles, &
@@ -778,7 +778,7 @@ subroutine ddx_multipole_electrostatics_1(c_ddx, nsph, ncav, nmultipoles, multip
     call c_f_pointer(c_ddx, ddx)
     mmax = int(sqrt(dble(nmultipoles)) - 1d0)
     call build_e(ddx%params, ddx%constants, ddx%workspace, multipoles, mmax, &
-            & phi_cav, e_cav)
+            & phi_cav, e_cav, ddx%error)
 end
 
 subroutine ddx_multipole_electrostatics_2(c_ddx, nsph, ncav, nmultipoles, multipoles, &
@@ -792,7 +792,7 @@ subroutine ddx_multipole_electrostatics_2(c_ddx, nsph, ncav, nmultipoles, multip
     call c_f_pointer(c_ddx, ddx)
     mmax = int(sqrt(dble(nmultipoles)) - 1d0)
     call build_g(ddx%params, ddx%constants, ddx%workspace, multipoles, mmax, &
-            & phi_cav, e_cav, g_cav)
+            & phi_cav, e_cav, g_cav, ddx%error)
 end
 
 subroutine ddx_multipole_psi(c_ddx, nbasis, nsph, nmultipoles, multipoles, psi) bind(C)
@@ -821,7 +821,7 @@ subroutine ddx_multipole_forces(c_ddx, c_state, nsph, ncav, nmultipoles, multipo
     call c_f_pointer(c_state, state)
     mmax = int(sqrt(dble(nmultipoles)) - 1d0)
     call grad_phi(ddx%params, ddx%constants, ddx%workspace, state, mmax, &
-        & multipoles, forces, e_cav)
+        & multipoles, forces, e_cav, ddx%error)
 end
 
 end

--- a/src/ddx_constants.f90
+++ b/src/ddx_constants.f90
@@ -237,6 +237,7 @@ contains
 !!
 !! @param[in] params: Object containing all inputs.
 !! @param[out] constants: Object containing all constants.
+!! @param[inout] error: ddX error
 !!
 subroutine constants_init(params, constants, error)
     use complex_bessel
@@ -725,10 +726,6 @@ subroutine build_b(constants, params, error)
 end subroutine build_b
 
 !> Computation of P_chi
-!!
-!! @param[in]  isph : Sphere number
-!! @param[out] pmat : Matrix of size nbasis X (lmax0+1)^2, Fixed lmax0
-!!
 subroutine mkpmat(params, constants, isph, pmat)
     type(ddx_params_type), intent(in)  :: params
     type(ddx_constants_type), intent(in)  :: constants
@@ -763,6 +760,8 @@ end subroutine mkpmat
 !!
 !! @param[in] params: Object containing all inputs.
 !! @param[inout] constants: Object containing all constants.
+!! @param[inout] error: ddX error
+!!
 subroutine constants_geometry_init(params, constants, error)
     !! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -775,7 +774,6 @@ subroutine constants_geometry_init(params, constants, error)
         & old_lwork, icav, info
     integer, allocatable :: work(:, :), tmp_work(:, :)
     real(dp) :: start_time
-    write(6,*) "HERE HERE HERE"
     !! The code
     ! Prepare FMM structures if needed
     start_time = omp_get_wtime()
@@ -1340,7 +1338,6 @@ real(dp) function dfsw(t, se, eta)
 end function dfsw
 
 !> Compute preconditioner
-!!
 !! assemble the diagonal blocks of the reps matrix
 !! then invert them to build the preconditioner
 subroutine mkprec(lmax, nbasis, nsph, ngrid, eps, ui, wgrid, vgrid, &
@@ -1433,6 +1430,7 @@ end subroutine mkprec
 !! @param[out] cnode: Center of a bounding sphere of each node
 !! @param[out] rnode: Radius of a bounding sphere of each node
 !! @param[out] snode: Array of leaf nodes containing input spheres
+!! @param[inout] error: ddX error
 subroutine tree_rib_build(nsph, csph, rsph, order, cluster, children, parent, &
         & cnode, rnode, snode, error)
     ! Inputs
@@ -1559,6 +1557,7 @@ end subroutine tree_rib_build
 !!      `order(1:div)` correspond to the first subcluster and indexes
 !!      `order(div+1:n)` correspond to the second subcluster.
 !! @param[out] div: Break point of `order` array between two clusters.
+!! @param[inout] error: ddX error
 subroutine tree_rib_node_bisect(nsph, csph, n, order, div, error)
     ! Inputs
     integer, intent(in) :: nsph, n
@@ -1818,6 +1817,7 @@ end subroutine tree_get_farnear
 !> @ingroup Fortran_interface_core
 !!
 !! @param[out] constants: Precomputed constants
+!! @param[inout] error: ddX error
 !!
 subroutine constants_free(constants)
     implicit none

--- a/src/ddx_constants.f90
+++ b/src/ddx_constants.f90
@@ -224,10 +224,6 @@ type ddx_constants_type
     !> Whether the diagonal of the matrices has to be used in the mvp for
     !! ddCOSMO, ddPCM or inner ddLPB iterations
     logical  :: dodiag
-    !> Flag if there were an error
-    integer :: error_flag = 2
-    !> Last error message
-    character(len=255) :: error_message
 end type ddx_constants_type
 
 contains
@@ -1819,9 +1815,10 @@ end subroutine tree_get_farnear
 !! @param[out] constants: Precomputed constants
 !! @param[inout] error: ddX error
 !!
-subroutine constants_free(constants)
+subroutine constants_free(constants, error)
     implicit none
     type(ddx_constants_type), intent(out) :: constants
+    type(ddx_error_type), intent(inout) :: error
     integer :: istat
 
     istat = 0
@@ -1829,403 +1826,305 @@ subroutine constants_free(constants)
     if (allocated(constants % vscales)) then
         deallocate(constants % vscales, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`vscales` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`vscales` deallocation failed!")
         end if
     end if
     if (allocated(constants % v4pi2lp1)) then
         deallocate(constants % v4pi2lp1, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`v4pi2lp1` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`v4pi2lp1` deallocation failed!")
         end if
     end if
     if (allocated(constants % vscales_rel)) then
         deallocate(constants % vscales_rel, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`vscales_rel` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`vscales_rel` deallocation failed!")
         end if
     end if
     if (allocated(constants % vfact)) then
         deallocate(constants % vfact, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`vfact` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`vfact` deallocation failed!")
         end if
     end if
     if (allocated(constants % vcnk)) then
         deallocate(constants % vcnk, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`vcnk` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`vcnk` deallocation failed!")
         end if
     end if
     if (allocated(constants % m2l_ztranslate_coef)) then
         deallocate(constants % m2l_ztranslate_coef, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`m2l_ztranslate_coef` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, &
+                & "`m2l_ztranslate_coef` deallocation failed!")
         end if
     end if
     if (allocated(constants % m2l_ztranslate_adj_coef)) then
         deallocate(constants % m2l_ztranslate_adj_coef, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`m2l_ztranslate_adj_coef` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, &
+                & "`m2l_ztranslate_adj_coef` deallocation failed!")
         end if
     end if
     if (allocated(constants % cgrid)) then
         deallocate(constants % cgrid, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`cgrid` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`cgrid` deallocation failed!")
         end if
     end if
     if (allocated(constants % wgrid)) then
         deallocate(constants % wgrid, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`wgrid` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`wgrid` deallocation failed!")
         end if
     end if
     if (allocated(constants % vgrid)) then
         deallocate(constants % vgrid, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`vgrid` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`vgrid` deallocation failed!")
         end if
     end if
     if (allocated(constants % vwgrid)) then
         deallocate(constants % vwgrid, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`vwgrid` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`vwgrid` deallocation failed!")
         end if
     end if
     if (allocated(constants % vgrid2)) then
         deallocate(constants % vgrid2, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`vgrid2` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`vgrid2` deallocation failed!")
         end if
     end if
     if (allocated(constants % pchi)) then
         deallocate(constants % pchi, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`pchi` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`pchi` deallocation failed!")
         end if
     end if
     if (allocated(constants % c_ik)) then
         deallocate(constants % c_ik, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`c_ik` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`c_ik` deallocation failed!")
         end if
     end if
     if (allocated(constants % si_ri)) then
         deallocate(constants % si_ri, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`si_ri` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`si_ri` deallocation failed!")
         end if
     end if
     if (allocated(constants % di_ri)) then
         deallocate(constants % di_ri, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`di_ri` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`di_ri` deallocation failed!")
         end if
     end if
     if (allocated(constants % sk_ri)) then
         deallocate(constants % sk_ri, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`sk_ri` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`sk_ri` deallocation failed!")
         end if
     end if
     if (allocated(constants % dk_ri)) then
         deallocate(constants % dk_ri, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`dk_ri` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`dk_ri` deallocation failed!")
         end if
     end if
     if (allocated(constants % termimat)) then
         deallocate(constants % termimat, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`termimat` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`termimat` deallocation failed!")
         end if
     end if
     if (allocated(constants % b)) then
         deallocate(constants % b, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`b` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`b` deallocation failed!")
         end if
     end if
     if (allocated(constants % l)) then
         deallocate(constants % l, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`l` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`l` deallocation failed!")
         end if
     end if
     if (allocated(constants % inl)) then
         deallocate(constants % inl, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`inl` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`inl` deallocation failed!")
         end if
     end if
     if (allocated(constants % nl)) then
         deallocate(constants % nl, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`nl` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`nl` deallocation failed!")
         end if
     end if
     if (allocated(constants % itrnl)) then
         deallocate(constants % itrnl, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`itrnl` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`itrnl` deallocation failed!")
         end if
     end if
     if (allocated(constants % fi)) then
         deallocate(constants % fi, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`fi` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`fi` deallocation failed!")
         end if
     end if
     if (allocated(constants % ui)) then
         deallocate(constants % ui, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`ui` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`ui` deallocation failed!")
         end if
     end if
     if (allocated(constants % ui_cav)) then
         deallocate(constants % ui_cav, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`ui_cav` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`ui_cav` deallocation failed!")
         end if
     end if
     if (allocated(constants % zi)) then
         deallocate(constants % zi, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`zi` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`zi` deallocation failed!")
         end if
     end if
     if (allocated(constants % ncav_sph)) then
         deallocate(constants % ncav_sph, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`ncav_sph` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`ncav_sph` deallocation failed!")
         end if
     end if
     if (allocated(constants % ccav)) then
         deallocate(constants % ccav, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`ccav` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`ccav` deallocation failed!")
         end if
     end if
     if (allocated(constants % icav_ia)) then
         deallocate(constants % icav_ia, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`icav_ia` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`icav_ia` deallocation failed!")
         end if
     end if
     if (allocated(constants % icav_ja)) then
         deallocate(constants % icav_ja, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`icav_ja` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`icav_ja` deallocation failed!")
         end if
     end if
     if (allocated(constants % rx_prc)) then
         deallocate(constants % rx_prc, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`rx_prc` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`rx_prc` deallocation failed!")
         end if
     end if
     if (allocated(constants % order)) then
         deallocate(constants % order, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`order` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`order` deallocation failed!")
         end if
     end if
     if (allocated(constants % cluster)) then
         deallocate(constants % cluster, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`cluster` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`cluster` deallocation failed!")
         end if
     end if
     if (allocated(constants % children)) then
         deallocate(constants % children, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`children` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`children` deallocation failed!")
         end if
     end if
     if (allocated(constants % parent)) then
         deallocate(constants % parent, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`parent` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`parent` deallocation failed!")
         end if
     end if
     if (allocated(constants % cnode)) then
         deallocate(constants % cnode, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`cnode` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`cnode` deallocation failed!")
         end if
     end if
     if (allocated(constants % rnode)) then
         deallocate(constants % rnode, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`rnode` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`rnode` deallocation failed!")
         end if
     end if
     if (allocated(constants % snode)) then
         deallocate(constants % snode, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`snode` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`snode` deallocation failed!")
         end if
     end if
     if (allocated(constants % sk_rnode)) then
         deallocate(constants % sk_rnode, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`sk_rnode` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`sk_rnode` deallocation failed!")
         end if
     end if
     if (allocated(constants % si_rnode)) then
         deallocate(constants % si_rnode, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`si_rnode` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`si_rnode` deallocation failed!")
         end if
     end if
     if (allocated(constants % nfar)) then
         deallocate(constants % nfar, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`nfar` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`nfar` deallocation failed!")
         end if
     end if
     if (allocated(constants % nnear)) then
         deallocate(constants % nnear, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`nnear` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`nnear` deallocation failed!")
         end if
     end if
     if (allocated(constants % far)) then
         deallocate(constants % far, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`far` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`far` deallocation failed!")
         end if
     end if
     if (allocated(constants % near)) then
         deallocate(constants % near, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`near` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`near` deallocation failed!")
         end if
     end if
     if (allocated(constants % sfar)) then
         deallocate(constants % sfar, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`sfar` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`sfar` deallocation failed!")
         end if
     end if
     if (allocated(constants % snear)) then
         deallocate(constants % snear, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`snear` deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`snear` deallocation failed!")
         end if
     end if
     if (allocated(constants % m2l_ztranslate_coef)) then
         deallocate(constants % m2l_ztranslate_coef, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`m2l_ztranslate_coef` " // &
-                & "deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`m2l_ztranslate_coef` " // &
+                & "deallocation failed!")
         end if
     end if
     if (allocated(constants % m2l_ztranslate_adj_coef)) then
         deallocate(constants % m2l_ztranslate_adj_coef, stat=istat)
         if (istat .ne. 0) then
-            constants % error_message = "`m2l_ztranslate_adj_coef` " // &
-                & "deallocation failed!"
-            constants % error_flag = 1
-            return
+            call update_error(error, "`m2l_ztranslate_adj_coef` " // &
+                & "deallocation failed!")
         end if
     end if
 end subroutine constants_free

--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -309,12 +309,14 @@ end subroutine ddinit
 !! @param[in] params: User specified parameters
 !! @param[in] constants: Precomputed constants
 !! @param[inout] state: ddx state (contains solutions and RHSs)
+!! @param[inout] error: ddX error
 !!
-subroutine ddx_init_state(params, constants, state)
+subroutine ddx_init_state(params, constants, state, error)
     implicit none
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_state_type), intent(out) :: state
+    type(ddx_error_type), intent(inout) :: error
     integer :: istatus
 
     state % error_flag = 0
@@ -322,28 +324,24 @@ subroutine ddx_init_state(params, constants, state)
 
     allocate(state % psi(constants % nbasis, params % nsph), stat=istatus)
     if (istatus .ne. 0) then
-        state % error_flag = 1
-        state % error_message = "ddinit: `psi` allocation failed"
+        call update_error(error, "ddinit: `psi` allocation failed")
         return
     end if
     allocate(state % phi_cav(constants % ncav), stat=istatus)
     if (istatus .ne. 0) then
-        state % error_flag = 1
-        state % error_message = "ddinit: `phi_cav` allocation failed"
+        call update_error(error, "ddinit: `phi_cav` allocation failed")
         return
     end if
     allocate(state % gradphi_cav(3, constants % ncav), stat=istatus)
     if (istatus .ne. 0) then
-        state % error_flag = 1
-        state % error_message = "ddinit: `gradphi_cav` allocation failed"
+        call update_error(error, "ddinit: `gradphi_cav` allocation failed")
         return
     end if
     allocate(state % q(constants % nbasis, &
         & params % nsph), stat=istatus)
     if (istatus .ne. 0) then
-        state % error_flag = 1
-        state % error_message = "ddinit: `q` " // &
-            & "allocation failed"
+        call update_error(error, "ddinit: `q` " // &
+            & "allocation failed")
         return
     end if
 
@@ -352,64 +350,56 @@ subroutine ddx_init_state(params, constants, state)
         allocate(state % phi_grid(params % ngrid, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `phi_grid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `phi_grid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % phi(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `phi` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `phi` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % xs(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `xs` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `xs` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % xs_rel_diff(params % maxiter), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `xs_rel_diff` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `xs_rel_diff` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % s(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `s` " // &
-            & "allocation failed"
+            call update_error(error, "ddinit: `s` " // &
+            & "allocation failed")
             return
         end if
         allocate(state % s_rel_diff(params % maxiter), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `s_rel_diff` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `s_rel_diff` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % sgrid(params % ngrid, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `sgrid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `sgrid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % zeta(constants % ncav), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `zeta` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `zeta` " // &
+                & "allocation failed")
             return
         end if
     ! PCM model
@@ -417,128 +407,112 @@ subroutine ddx_init_state(params, constants, state)
         allocate(state % phi_grid(params % ngrid, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `phi_grid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `phi_grid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % phi(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `phi` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `phi` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % phiinf(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `phiinf` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `phiinf` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % phieps(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `phieps` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `phieps` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % phieps_rel_diff(params % maxiter), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `xs_rel_diff` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `xs_rel_diff` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % xs(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `xs` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `xs` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % xs_rel_diff(params % maxiter), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `xs_rel_diff` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `xs_rel_diff` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % s(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `s` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `s` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % s_rel_diff(params % maxiter), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `xs_rel_diff` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `xs_rel_diff` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % sgrid(params % ngrid, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `sgrid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `sgrid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % y(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `y` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `y` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % y_rel_diff(params % maxiter), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `y_rel_diff` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `y_rel_diff` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % ygrid(params % ngrid, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `ygrid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `ygrid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % g(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `g` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `g` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % qgrid(params % ngrid, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `qgrid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `qgrid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % zeta(constants % ncav), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `zeta` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `zeta` " // &
+                & "allocation failed")
             return
         end if
     ! LPB model
@@ -546,131 +520,115 @@ subroutine ddx_init_state(params, constants, state)
         allocate(state % phi_grid(params % ngrid, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `phi_grid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `phi_grid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % phi(constants % nbasis, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `phi` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `phi` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % zeta(constants % ncav), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `zeta` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `zeta` " // &
+                & "allocation failed")
             !write(*, *) "Error in allocation of M2P matrices"
             return
         end if
         allocate(state % x_lpb_rel_diff(params % maxiter), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `x_lpb_rel_diff` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `x_lpb_rel_diff` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % rhs_lpb(constants % nbasis, &
             & params % nsph, 2), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `rhs_lpb` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `rhs_lpb` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % rhs_adj_lpb(constants % nbasis, &
             & params % nsph, 2), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `rhs_adj_lpb` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `rhs_adj_lpb` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % x_lpb(constants % nbasis, &
             & params % nsph, 2), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `x_lpb` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `x_lpb` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % x_adj_lpb(constants % nbasis, &
             & params % nsph, 2), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `x_adj_lpb` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `x_adj_lpb` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % x_adj_lpb_rel_diff(params % maxiter), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `x_adj_lpb_rel_diff` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `x_adj_lpb_rel_diff` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % g_lpb(params % ngrid, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `g_lpb` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `g_lpb` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % f_lpb(params % ngrid, &
             & params % nsph), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `f_lpb` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `f_lpb` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % zeta_dip(3, constants % ncav), stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `zeta_dip` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `zeta_dip` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % x_adj_re_grid(params % ngrid, params % nsph), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `x_adj_re_grid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `x_adj_re_grid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % x_adj_r_grid(params % ngrid, params % nsph), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `x_adj_r_grid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `x_adj_r_grid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % x_adj_e_grid(params % ngrid, params % nsph), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `x_adj_e_grid` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `x_adj_e_grid` " // &
+                & "allocation failed")
             return
         end if
         allocate(state % phi_n(params % ngrid, params % nsph), &
             & stat=istatus)
         if (istatus .ne. 0) then
-            state % error_flag = 1
-            state % error_message = "ddinit: `phi_n` " // &
-                & "allocation failed"
+            call update_error(error, "ddinit: `phi_n` " // &
+                & "allocation failed")
             return
         end if
     end if

--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -291,7 +291,7 @@ subroutine ddinit(nsph, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         return
     end if
     call workspace_init(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace)
+        & ddx_data % workspace, error)
     if (error % flag .ne. 0) then
         call update_error(error, "workspace_init returned an error, exiting")
         return

--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -186,9 +186,6 @@ type ddx_state_type
     real(dp) :: hsp_time
     real(dp) :: hsp_adj_time
 
-    integer :: error_flag = 0
-    character(len=255) :: error_message
-
 end type ddx_state_type
 
 !> Main ddX type that stores all the required information.

--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -677,7 +677,6 @@ subroutine ddfromfile(fname, ddx_data, tol, charges, error)
     if(ngrid .lt. 0) then
         call update_error(error, "Error on the 5th line of a config file " // &
             & trim(fname) // ": `ngrid` must be a non-negative integer value.")
-        error % flag = 1
     end if
     ! Dielectric permittivity constant of the solvent
     read(100, *) eps

--- a/src/ddx_cosmo.f90
+++ b/src/ddx_cosmo.f90
@@ -53,20 +53,20 @@ subroutine ddcosmo(params, constants, workspace, state, phi_cav, &
 
     call ddcosmo_setup(params, constants, workspace, state, phi_cav, psi, error)
     if (error % flag .ne. 0) then
-        call update_error(error,
-            "ddlpb: ddcosmo_setup returned an error, exiting")
+        call update_error(error, &
+            & "ddlpb: ddcosmo_setup returned an error, exiting")
         return
     end if
     call ddcosmo_guess(params, constants, workspace, state, error)
     if (error % flag .ne. 0) then
-        call update_error(error,
-            "ddlpb: ddcosmo_guess returned an error, exiting")
+        call update_error(error, &
+            & "ddlpb: ddcosmo_guess returned an error, exiting")
         return
     end if
     call ddcosmo_solve(params, constants, workspace, state, tol, error)
     if (error % flag .ne. 0) then
-        call update_error(error,
-            "ddlpb: ddcosmo_solve returned an error, exiting")
+        call update_error(error, &
+            & "ddlpb: ddcosmo_solve returned an error, exiting")
         return
     end if
 
@@ -77,15 +77,15 @@ subroutine ddcosmo(params, constants, workspace, state, phi_cav, &
         ! solve the adjoint
         call ddcosmo_guess_adjoint(params, constants, workspace, state, error)
         if (error % flag .ne. 0) then
-            call update_error(error,
-                "ddlpb: ddcosmo_guess_adjoint returned an error, exiting")
+            call update_error(error, &
+                & "ddlpb: ddcosmo_guess_adjoint returned an error, exiting")
             return
         end if
         call ddcosmo_solve_adjoint(params, constants, workspace, state, tol, &
             & error)
         if (error % flag .ne. 0) then
-            call update_error(error,
-                "ddlpb: ddcosmo_guess_adjoint returned an error, exiting")
+            call update_error(error, &
+                & "ddlpb: ddcosmo_guess_adjoint returned an error, exiting")
             return
         end if
 

--- a/src/ddx_cosmo.f90
+++ b/src/ddx_cosmo.f90
@@ -52,8 +52,23 @@ subroutine ddcosmo(params, constants, workspace, state, phi_cav, &
     type(ddx_error_type), intent(inout) :: error
 
     call ddcosmo_setup(params, constants, workspace, state, phi_cav, psi, error)
+    if (error % flag .ne. 0) then
+        call update_error(error,
+            "ddlpb: ddcosmo_setup returned an error, exiting")
+        return
+    end if
     call ddcosmo_guess(params, constants, workspace, state, error)
+    if (error % flag .ne. 0) then
+        call update_error(error,
+            "ddlpb: ddcosmo_guess returned an error, exiting")
+        return
+    end if
     call ddcosmo_solve(params, constants, workspace, state, tol, error)
+    if (error % flag .ne. 0) then
+        call update_error(error,
+            "ddlpb: ddcosmo_solve returned an error, exiting")
+        return
+    end if
 
     call ddcosmo_energy(constants, state, esolv, error)
 
@@ -61,8 +76,18 @@ subroutine ddcosmo(params, constants, workspace, state, phi_cav, &
     if (params % force .eq. 1) then
         ! solve the adjoint
         call ddcosmo_guess_adjoint(params, constants, workspace, state, error)
+        if (error % flag .ne. 0) then
+            call update_error(error,
+                "ddlpb: ddcosmo_guess_adjoint returned an error, exiting")
+            return
+        end if
         call ddcosmo_solve_adjoint(params, constants, workspace, state, tol, &
             & error)
+        if (error % flag .ne. 0) then
+            call update_error(error,
+                "ddlpb: ddcosmo_guess_adjoint returned an error, exiting")
+            return
+        end if
 
         ! evaluate the solvent unspecific contribution analytical derivatives
         force = zero

--- a/src/ddx_definitions.f90
+++ b/src/ddx_definitions.f90
@@ -41,8 +41,6 @@ integer, parameter :: ng0(nllg) = (/ 6, 14, 26, 38, 50, 74, 86, 110, 146, &
     & 2030, 2354, 2702, 3074, 3470, 3890, 4334, 4802, 5294, 5810 /)
 !> Names of ddX models
 character(len=255), parameter :: model_str(3) = (/ "COSMO", "PCM  ", "LPB  " /)
-!> length of the error message
-integer, parameter :: error_length = 2000
 
 end module ddx_definitions
 

--- a/src/ddx_definitions.f90
+++ b/src/ddx_definitions.f90
@@ -41,6 +41,8 @@ integer, parameter :: ng0(nllg) = (/ 6, 14, 26, 38, 50, 74, 86, 110, 146, &
     & 2030, 2354, 2702, 3074, 3470, 3890, 4334, 4802, 5294, 5810 /)
 !> Names of ddX models
 character(len=255), parameter :: model_str(3) = (/ "COSMO", "PCM  ", "LPB  " /)
+!> length of the error message
+integer, parameter :: error_length = 2000
 
 end module ddx_definitions
 

--- a/src/ddx_driver.f90
+++ b/src/ddx_driver.f90
@@ -172,14 +172,14 @@ write(*, 100) "Psi time:", finish_time-start_time, " seconds"
 ! STEP 4: solve the primal linear system.
 if (ddx_data % params % model .eq. 1) then
     call ddcosmo_setup(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, state, phi_cav, psi)
+        & ddx_data % workspace, state, phi_cav, psi, error)
     call ddcosmo_guess(ddx_data % params, ddx_data % constants, &
         & ddx_data % workspace, state, error)
     call ddcosmo_solve(ddx_data % params, ddx_data % constants, &
         & ddx_data % workspace, state, tol, error)
 else if (ddx_data % params % model .eq. 2) then
     call ddpcm_setup(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, state, phi_cav, psi)
+        & ddx_data % workspace, state, phi_cav, psi, error)
     call ddpcm_guess(ddx_data % params, ddx_data % constants, &
         & ddx_data % workspace, state, error)
     call ddpcm_solve(ddx_data % params, ddx_data % constants, &
@@ -196,11 +196,11 @@ call check_error(error)
 
 ! STEP 5: compute the solvation energy
 if (ddx_data % params % model .eq. 1) then
-    call ddcosmo_energy(ddx_data % constants, state, esolv)
+    call ddcosmo_energy(ddx_data % constants, state, esolv, error)
 else if (ddx_data % params % model .eq. 2) then
-    call ddpcm_energy(ddx_data % constants, state, esolv)
+    call ddpcm_energy(ddx_data % constants, state, esolv, error)
 else if (ddx_data % params % model .eq. 3) then
-    call ddlpb_energy(ddx_data % constants, state, esolv)
+    call ddlpb_energy(ddx_data % constants, state, esolv, error)
 end if
 
 ! STEP 6: if required solve the adjoint linear system. The adjoint
@@ -239,10 +239,10 @@ if (ddx_data % params % force .eq. 1) then
 
     if (ddx_data % params % model .eq. 1) then
         call ddcosmo_solvation_force_terms(ddx_data % params, &
-            & ddx_data % constants, ddx_data % workspace, state, force)
+            & ddx_data % constants, ddx_data % workspace, state, force, error)
     else if (ddx_data % params % model .eq. 2) then
         call ddpcm_solvation_force_terms(ddx_data % params, &
-            & ddx_data % constants, ddx_data % workspace, state, force)
+            & ddx_data % constants, ddx_data % workspace, state, force, error)
     else if (ddx_data % params % model .eq. 3) then
         call ddlpb_solvation_force_terms(ddx_data % params, &
             & ddx_data % constants, ddx_data % workspace, state, g_cav, force, error)

--- a/src/ddx_driver.f90
+++ b/src/ddx_driver.f90
@@ -186,7 +186,7 @@ else if (ddx_data % params % model .eq. 2) then
         & ddx_data % workspace, state, tol, error)
 else if (ddx_data % params % model .eq. 3) then
     call ddlpb_setup(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, state, phi_cav, e_cav, psi)
+        & ddx_data % workspace, state, phi_cav, e_cav, psi, error)
     call ddlpb_guess(ddx_data % params, ddx_data % constants, &
         & ddx_data % workspace, state, tol, error)
     call ddlpb_solve(ddx_data % params, ddx_data % constants, &
@@ -399,7 +399,7 @@ if (allocated(force)) then
     end if
 end if
 
-call ddx_free_state(state)
-call ddfree(ddx_data)
+call ddx_free_state(state, error)
+call ddfree(ddx_data, error)
 
 end program main

--- a/src/ddx_driver.f90
+++ b/src/ddx_driver.f90
@@ -46,12 +46,8 @@ write(6, *) "Using provided file ", trim(fname), " as a config file"
 start_time = omp_get_wtime()
 call ddfromfile(fname, ddx_data, tol, charges, error)
 finish_time = omp_get_wtime()
-write(*, 100) "Initialization time:", finish_time - start_time, &
-    & " seconds"
-if (error % flag .ne. 0) then
-    write(6, *) error % message
-    stop error % flag
-end if
+write(*, 100) "Initialization time:", finish_time - start_time, " seconds"
+call check_error(error)
 
 ! STEP 2: Initialization of the state.
 ! The state is a high level object which is related to solving the

--- a/src/ddx_driver.f90
+++ b/src/ddx_driver.f90
@@ -55,11 +55,8 @@ call check_error(error)
 ! model (ddx_data). Different states can be used at the same time with
 ! a given model, for instance when solving for different solutes,
 ! or for different states of the solute.
-call ddx_init_state(ddx_data % params, ddx_data % constants, state)
-if (state % error_flag .ne. 0) then
-  write(6, *) state % error_message
-  stop
-end if
+call ddx_init_state(ddx_data % params, ddx_data % constants, state, error)
+call check_error(error)
 
 ! Print the ddX banner
 call get_banner(banner)

--- a/src/ddx_driver.f90
+++ b/src/ddx_driver.f90
@@ -144,13 +144,13 @@ end if
 ! Compute the required electrostatic properties.
 if (do_phi .and. do_e .and. do_g) then
     call build_g(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, multipoles, 0, phi_cav, e_cav, g_cav)
+        & ddx_data % workspace, multipoles, 0, phi_cav, e_cav, g_cav, error)
 else if (do_phi .and. do_e) then
     call build_e(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, multipoles, 0, phi_cav, e_cav)
+        & ddx_data % workspace, multipoles, 0, phi_cav, e_cav, error)
 else
     call build_phi(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, multipoles, 0, phi_cav)
+        & ddx_data % workspace, multipoles, 0, phi_cav, error)
 end if
 
 finish_time = omp_get_wtime()
@@ -256,12 +256,12 @@ if (ddx_data % params % force .eq. 1) then
     start_time = omp_get_wtime()
     call grad_phi_for_charges(ddx_data % params, &
         & ddx_data % constants, ddx_data % workspace, state, &
-        & charges, force, e_cav)
+        & charges, force, e_cav, error)
     if (ddx_data % params % model .eq. 3) then
         ! ddLPB has another term in the multipolar forces stemming
         ! from the electric field in the RHS
         call grad_e_for_charges(ddx_data % params, ddx_data % constants, &
-            & ddx_data % workspace, state, charges, force)
+            & ddx_data % workspace, state, charges, force, error)
     end if
     finish_time = omp_get_wtime()
     write(*, 100) "multipolar force terms time:", &

--- a/src/ddx_driver.f90
+++ b/src/ddx_driver.f90
@@ -174,23 +174,23 @@ if (ddx_data % params % model .eq. 1) then
     call ddcosmo_setup(ddx_data % params, ddx_data % constants, &
         & ddx_data % workspace, state, phi_cav, psi)
     call ddcosmo_guess(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, state)
+        & ddx_data % workspace, state, error)
     call ddcosmo_solve(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, state, tol)
+        & ddx_data % workspace, state, tol, error)
 else if (ddx_data % params % model .eq. 2) then
     call ddpcm_setup(ddx_data % params, ddx_data % constants, &
         & ddx_data % workspace, state, phi_cav, psi)
     call ddpcm_guess(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, state)
+        & ddx_data % workspace, state, error)
     call ddpcm_solve(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, state, tol)
+        & ddx_data % workspace, state, tol, error)
 else if (ddx_data % params % model .eq. 3) then
     call ddlpb_setup(ddx_data % params, ddx_data % constants, &
         & ddx_data % workspace, state, phi_cav, e_cav, psi)
     call ddlpb_guess(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, state, tol)
+        & ddx_data % workspace, state, tol, error)
     call ddlpb_solve(ddx_data % params, ddx_data % constants, &
-        & ddx_data % workspace, state, tol)
+        & ddx_data % workspace, state, tol, error)
 end if
 
 ! STEP 5: compute the solvation energy
@@ -209,19 +209,19 @@ end if
 if (ddx_data % params % force .eq. 1) then
     if (ddx_data % params % model .eq. 1) then
         call ddcosmo_guess_adjoint(ddx_data % params, &
-            & ddx_data % constants, ddx_data % workspace, state)
+            & ddx_data % constants, ddx_data % workspace, state, error)
         call ddcosmo_solve_adjoint(ddx_data % params, &
-            & ddx_data % constants, ddx_data % workspace, state, tol)
+            & ddx_data % constants, ddx_data % workspace, state, tol, error)
     else if (ddx_data % params % model .eq. 2) then
         call ddpcm_guess_adjoint(ddx_data % params, &
-            & ddx_data % constants, ddx_data % workspace, state)
+            & ddx_data % constants, ddx_data % workspace, state, error)
         call ddpcm_solve_adjoint(ddx_data % params, &
-            & ddx_data % constants, ddx_data % workspace, state, tol)
+            & ddx_data % constants, ddx_data % workspace, state, tol, error)
     else if (ddx_data % params % model .eq. 3) then
         call ddlpb_guess_adjoint(ddx_data % params, &
-            & ddx_data % constants, ddx_data % workspace, state, tol)
+            & ddx_data % constants, ddx_data % workspace, state, tol, error)
         call ddlpb_solve_adjoint(ddx_data % params, &
-            & ddx_data % constants, ddx_data % workspace, state, tol)
+            & ddx_data % constants, ddx_data % workspace, state, tol, error)
     end if
 end if
 
@@ -257,11 +257,13 @@ if (ddx_data % params % force .eq. 1) then
     call grad_phi_for_charges(ddx_data % params, &
         & ddx_data % constants, ddx_data % workspace, state, &
         & charges, force, e_cav, error)
+    call check_error(error)
     if (ddx_data % params % model .eq. 3) then
         ! ddLPB has another term in the multipolar forces stemming
         ! from the electric field in the RHS
         call grad_e_for_charges(ddx_data % params, ddx_data % constants, &
             & ddx_data % workspace, state, charges, force, error)
+        call check_error(error)
     end if
     finish_time = omp_get_wtime()
     write(*, 100) "multipolar force terms time:", &

--- a/src/ddx_driver.f90
+++ b/src/ddx_driver.f90
@@ -192,6 +192,7 @@ else if (ddx_data % params % model .eq. 3) then
     call ddlpb_solve(ddx_data % params, ddx_data % constants, &
         & ddx_data % workspace, state, tol, error)
 end if
+call check_error(error)
 
 ! STEP 5: compute the solvation energy
 if (ddx_data % params % model .eq. 1) then
@@ -224,6 +225,7 @@ if (ddx_data % params % force .eq. 1) then
             & ddx_data % constants, ddx_data % workspace, state, tol, error)
     end if
 end if
+call check_error(error)
 
 ! STEP 7: if required compute the solute aspecific contributions to the
 ! forces.
@@ -243,7 +245,7 @@ if (ddx_data % params % force .eq. 1) then
             & ddx_data % constants, ddx_data % workspace, state, force)
     else if (ddx_data % params % model .eq. 3) then
         call ddlpb_solvation_force_terms(ddx_data % params, &
-            & ddx_data % constants, ddx_data % workspace, state, g_cav, force)
+            & ddx_data % constants, ddx_data % workspace, state, g_cav, force, error)
     end if
 end if
 

--- a/src/ddx_driver.f90
+++ b/src/ddx_driver.f90
@@ -22,6 +22,7 @@ character(len=255) :: fname
 character(len=2047) :: banner
 type(ddx_type) :: ddx_data
 type(ddx_state_type) :: state
+type(ddx_error_type) :: error
 real(dp), allocatable :: phi_cav(:), e_cav(:, :), &
     & g_cav(:, :, :), psi(:, :), force(:, :), charges(:), &
     & multipoles(:, :)
@@ -43,13 +44,13 @@ write(6, *) "Using provided file ", trim(fname), " as a config file"
 ! The model is a container for all the parameters, precomputed constants
 ! and preallocated workspaces.
 start_time = omp_get_wtime()
-call ddfromfile(fname, ddx_data, tol, charges)
+call ddfromfile(fname, ddx_data, tol, charges, error)
 finish_time = omp_get_wtime()
 write(*, 100) "Initialization time:", finish_time - start_time, &
     & " seconds"
-if (ddx_data % error_flag .ne. 0) then
-  write(6, *) ddx_data % error_message
-  stop
+if (error % flag .ne. 0) then
+    write(6, *) error % message
+    stop error % flag
 end if
 
 ! STEP 2: Initialization of the state.

--- a/src/ddx_errors.f90
+++ b/src/ddx_errors.f90
@@ -17,7 +17,7 @@ contains
 subroutine print_error(error)
     implicit none
     type(ddx_error_type), intent(in) :: error
-    write(6, "(A)") error % message(0:error % message_length-2)
+    write(6, "(A)") error % message(1:error % message_length-2)
 end subroutine print_error
 
 subroutine check_error(error)
@@ -53,6 +53,7 @@ subroutine reset_error(error)
     type(ddx_error_type), intent(inout) :: error
     integer :: i
     error % flag = 0
+    error % message_length = 1
     do i = 1, error % max_length
         error % message(i:i) = " "
     end do

--- a/src/ddx_errors.f90
+++ b/src/ddx_errors.f90
@@ -1,0 +1,59 @@
+module ddx_errors
+
+!> ddX type for containing error information
+type ddx_error_type
+    !> Flag for error codes
+    integer :: flag = 0
+    !> Error message log
+    integer :: max_length = 2000
+    character(len=2000) :: message
+    integer :: message_length = 1
+end type ddx_error_type
+
+contains
+
+subroutine print_error(error)
+    implicit none
+    type(ddx_error_type), intent(in) :: error
+    write(6, "(A)") error % message(0:error % message_length-2)
+end subroutine print_error
+
+subroutine check_error(error)
+    implicit none
+    type(ddx_error_type), intent(in) :: error
+    if (error % flag .ne. 0) then
+        call print_error(error)
+        stop error % flag
+    end if
+end subroutine check_error
+
+subroutine update_error(error, message)
+    implicit none
+    type(ddx_error_type), intent(inout) :: error
+    character(len=*) :: message
+    integer :: message_start, message_stop
+    ! update the error flag by summing one
+    error % flag = error % flag + 1
+    message_start = error % message_length
+    message_stop = message_start + len(message) + 3
+    ! update the message if there is still space left
+    if (message_stop .lt. error % max_length) then
+        error % message(message_start:message_start) = " "
+        error % message(message_start + 1:message_stop - 2) = message
+        error % message(message_stop - 1:message_stop - 1) = achar(13)
+        error % message(message_stop:message_stop) = achar(10)
+        error % message_length = message_stop + 1
+    end if
+end subroutine update_error
+
+subroutine reset_error(error)
+    implicit none
+    type(ddx_error_type), intent(inout) :: error
+    integer :: i
+    error % flag = 0
+    do i = 1, error % max_length
+        error % message(i:i) = " "
+    end do
+end subroutine reset_error
+
+end module ddx_errors

--- a/src/ddx_errors.f90
+++ b/src/ddx_errors.f90
@@ -1,12 +1,14 @@
 module ddx_errors
 
+use ddx_definitions
+
 !> ddX type for containing error information
 type ddx_error_type
     !> Flag for error codes
     integer :: flag = 0
     !> Error message log
-    integer :: max_length = 2000
-    character(len=2000) :: message
+    integer :: max_length = 2047
+    character(len=2047) :: message
     integer :: message_length = 1
 end type ddx_error_type
 

--- a/src/ddx_errors.f90
+++ b/src/ddx_errors.f90
@@ -9,7 +9,7 @@ type ddx_error_type
     !> Error message log
     integer :: max_length = 2047
     character(len=2047) :: message
-    integer :: message_length = 1
+    integer :: message_length = 0
 end type ddx_error_type
 
 contains
@@ -17,7 +17,7 @@ contains
 subroutine print_error(error)
     implicit none
     type(ddx_error_type), intent(in) :: error
-    write(6, "(A)") error % message(1:error % message_length-2)
+    write(6, "(A)") error % message(1:1+error % message_length)
 end subroutine print_error
 
 subroutine check_error(error)
@@ -33,18 +33,25 @@ subroutine update_error(error, message)
     implicit none
     type(ddx_error_type), intent(inout) :: error
     character(len=*) :: message
-    integer :: message_start, message_stop
+    integer :: message_start, message_stop, message_length, total_length
     ! update the error flag by summing one
-    error % flag = error % flag + 1
-    message_start = error % message_length
-    message_stop = message_start + len(message) + 3
-    ! update the message if there is still space left
+    error % flag  = error % flag + 1
+    message_length = len(message)
+    total_length = message_length + 2
+    message_start = 1 + error % message_length
+    message_stop = message_start + total_length
+    ! update the message
     if (message_stop .lt. error % max_length) then
         error % message(message_start:message_start) = " "
-        error % message(message_start + 1:message_stop - 2) = message
-        error % message(message_stop - 1:message_stop - 1) = achar(13)
-        error % message(message_stop:message_stop) = achar(10)
-        error % message_length = message_stop + 1
+        error % message(message_start+1:message_stop-2) = message(1:message_length)
+        error % message(message_stop-1:message_stop-1) = achar(10)
+        error % message_length = error % message_length + total_length
+    else if (message_stop - error % max_length .gt. 3) then
+        message_length = error % max_length - message_start
+        error % message(message_start:message_start) = " "
+        error % message(message_start+1:error % max_length-2) = message(1:message_length-3)
+        error % message(error % max_length-1:error%max_length-1) = achar(10)
+        error % message_length = error % message_length + message_length
     end if
 end subroutine update_error
 
@@ -53,7 +60,7 @@ subroutine reset_error(error)
     type(ddx_error_type), intent(inout) :: error
     integer :: i
     error % flag = 0
-    error % message_length = 1
+    error % message_length = 0
     do i = 1, error % max_length
         error % message(i:i) = " "
     end do

--- a/src/ddx_gradients.f90
+++ b/src/ddx_gradients.f90
@@ -1610,4 +1610,586 @@ subroutine contract_grad_f_worker2(params, constants, workspace, &
 
 end subroutine contract_grad_f_worker2
 
+!> Sphere contribution to the ddPCM matrix gradient using N^2 code
+subroutine gradr_sph(params, constants, isph, vplm, vcos, vsin, basloc, &
+        & dbsloc, g, ygrid, fx)
+    implicit none
+    ! Inputs
+    type(ddx_params_type), intent(in) :: params
+    type(ddx_constants_type), intent(in) :: constants
+    integer, intent(in) :: isph
+    real(dp), intent(in) :: g(constants % nbasis, params % nsph), &
+        & ygrid(params % ngrid, params % nsph)
+    real(dp), intent(inout) :: vplm(constants % nbasis), vcos(params % lmax+1), &
+        & vsin(params % lmax+1), basloc(constants % nbasis), &
+        & dbsloc(3, constants % nbasis), fx(3)
+    ! various scratch arrays
+    real(dp) vik(3), sik(3), vki(3), ski(3), vkj(3), skj(3), vji(3), &
+        & sji(3), va(3), vb(3), a(3)
+    ! jacobian matrix
+    real(dp) sjac(3,3)
+    ! indexes
+    integer its, ik, ksph, l, m, ind, jsph, icomp, jcomp
+    ! various scalar quantities
+    real(dp) cx, cy, cz, vvki, tki, gg, fl, fac, vvkj, tkj
+    real(dp) tt, fcl, fjj, gi, fii, vvji, tji, qji
+    real(dp) b, vvik, tik, qik, tlow, thigh, duj
+    real(dp) :: rho, ctheta, stheta, cphi, sphi
+    real(dp), external :: dnrm2
+
+    tlow  = one - pt5*(one - params % se)*params % eta
+    thigh = one + pt5*(one + params % se)*params % eta
+
+    ! first set of contributions:
+    ! diagonal block, kc and part of kb
+
+    fx = zero
+    do its = 1, params % ngrid
+        ! sum over ksph in neighbors of isph
+        do ik = constants % inl(isph), constants % inl(isph+1) - 1
+            ksph = constants % nl(ik)
+            ! build geometrical quantities
+            cx = params % csph(1,ksph) + params % rsph(ksph)*constants % cgrid(1,its)
+            cy = params % csph(2,ksph) + params % rsph(ksph)*constants % cgrid(2,its)
+            cz = params % csph(3,ksph) + params % rsph(ksph)*constants % cgrid(3,its)
+            vki(1) = cx - params % csph(1,isph)
+            vki(2) = cy - params % csph(2,isph)
+            vki(3) = cz - params % csph(3,isph)
+            !vvki = sqrt(vki(1)*vki(1) + vki(2)*vki(2) + &
+            !    & vki(3)*vki(3))
+            vvki = dnrm2(3, vki, 1)
+            tki  = vvki/params % rsph(isph)
+
+            ! contributions involving grad i of uk come from the switching
+            ! region.
+            ! note: ui avoids contributions from points that are in the
+            ! switching between isph and ksph but are buried in a third
+            ! sphere.
+            if ((tki.gt.tlow).and.(tki.lt.thigh) .and. &
+                & constants % ui(its,ksph).gt.zero) then
+                ! other geometrical quantities
+                ski = vki/vvki
+
+                ! diagonal block kk contribution, with k in n(i)
+                gg = zero
+                do l = 0, params % lmax
+                    ind = l*l + l + 1
+                    fl = dble(l)
+                    fac = twopi/(two*fl + one)
+                    do m = -l, l
+                        !! DEBUG comment
+                        gg = gg + fac*constants % vgrid(ind+m,its)*g(ind+m,ksph)
+                    end do
+                end do
+
+                ! kc contribution
+                do jsph = 1, params % nsph
+                    if (jsph.ne.ksph .and. jsph.ne.isph) then 
+                        vkj(1) = cx - params % csph(1,jsph)
+                        vkj(2) = cy - params % csph(2,jsph)
+                        vkj(3) = cz - params % csph(3,jsph)
+                        vvkj = sqrt(vkj(1)*vkj(1) + vkj(2)*vkj(2) + &
+                            & vkj(3)*vkj(3))
+                        vvkj = dnrm2(3, vkj, 1)
+                        tkj  = vvkj/params % rsph(jsph)
+                        skj  = vkj/vvkj
+                        call ylmbas(skj, rho, ctheta, stheta, cphi, sphi, &
+                            & params % lmax, constants % vscales, basloc, &
+                            & vplm, vcos, vsin)
+                        tt = one/tkj
+                        do l = 0, params % lmax
+                            ind = l*l + l + 1
+                            fcl = - fourpi*dble(l)/(two*dble(l)+one)*tt
+                            do m = -l, l
+                                !! DEBUG comment
+                                gg = gg + fcl*g(ind+m,jsph)*basloc(ind+m)
+                            end do
+                            tt = tt/tkj
+                        end do
+                        !call fmm_m2p(vkj, params % rsph(jsph), &
+                        !    & params % lmax, constants % vscales_rel, -one, &
+                        !    & g(:, jsph), one, gg)
+                    end if
+                end do
+
+                ! part of kb contribution
+                call ylmbas(ski, rho, ctheta, stheta, cphi, sphi, &
+                    & params % lmax, constants % vscales, basloc, &
+                    & vplm, vcos, vsin)
+                tt = one/tki
+                do l = 0, params % lmax
+                    ind = l*l + l + 1
+                    fcl = - four*pi*dble(l)/(two*dble(l)+one)*tt
+                    do m = -l, l
+                        !! DEBUG comment
+                        gg = gg + fcl*g(ind+m,isph)*basloc(ind+m)
+                    end do
+                    tt = tt/tki
+                end do
+                !call fmm_m2p(vki, params % rsph(isph), &
+                !    & params % lmax, constants % vscales_rel, -one, &
+                !    & g(:, isph), one, gg)
+
+                ! common step, product with grad i uj
+                duj = dfsw(tki,params % se, params % eta)/params % rsph(isph)
+                fjj = duj*constants % wgrid(its)*gg*ygrid(its,ksph)
+                fx(1) = fx(1) - fjj*ski(1)
+                fx(2) = fx(2) - fjj*ski(2)
+                fx(3) = fx(3) - fjj*ski(3)
+            end if
+        end do
+
+        ! diagonal block ii contribution
+        if (constants % ui(its,isph).gt.zero.and.constants % ui(its,isph).lt.one) then
+            gi = zero
+            do l = 0, params % lmax
+                ind = l*l + l + 1
+                fl = dble(l)
+                fac = twopi/(two*fl + one)
+                do m = -l, l 
+                    !! DEBUG comment
+                    gi = gi + fac*constants % vgrid(ind+m,its)*g(ind+m,isph)
+                    !gi = gi + pt5*constants % vgrid2(ind+m,its)*g(ind+m,isph)
+                end do
+            end do
+            !do l = 0, (params % lmax+1)**2
+            !    gi = gi + constants % vgrid2(l, its)*g(l, isph)
+            !end do
+            !gi = pt5 * gi
+            fii = constants % wgrid(its)*gi*ygrid(its,isph)
+            fx(1) = fx(1) + fii*constants % zi(1,its,isph)
+            fx(2) = fx(2) + fii*constants % zi(2,its,isph)
+            fx(3) = fx(3) + fii*constants % zi(3,its,isph)
+        end if
+    end do
+
+    ! second set of contributions:
+    ! part of kb and ka
+    do its = 1, params % ngrid
+
+        ! run over all the spheres except isph 
+        do jsph = 1, params % nsph
+            if (constants % ui(its,jsph).gt.zero .and. jsph.ne.isph) then
+                ! build geometrical quantities
+                cx = params % csph(1,jsph) + params % rsph(jsph)*constants % cgrid(1,its)
+                cy = params % csph(2,jsph) + params % rsph(jsph)*constants % cgrid(2,its)
+                cz = params % csph(3,jsph) + params % rsph(jsph)*constants % cgrid(3,its)
+                vji(1) = cx - params % csph(1,isph)
+                vji(2) = cy - params % csph(2,isph)
+                vji(3) = cz - params % csph(3,isph)
+                !vvji = sqrt(vji(1)*vji(1) + vji(2)*vji(2) + &
+                !    &  vji(3)*vji(3))
+                vvji = dnrm2(3, vji, 1)
+                tji = vvji/params % rsph(isph)
+                qji = one/vvji
+                sji = vji/vvji
+
+                ! build the jacobian of sji
+                sjac = zero
+                sjac(1,1) = - one
+                sjac(2,2) = - one
+                sjac(3,3) = - one
+                do icomp = 1, 3
+                    do jcomp = 1, 3
+                        sjac(icomp,jcomp) = qji*(sjac(icomp,jcomp) &
+                            & + sji(icomp)*sji(jcomp))
+                    end do
+                end do
+
+                ! assemble the local basis and its gradient
+                !call dbasis(sji,basloc,dbsloc,vplm,vcos,vsin)
+                call dbasis(params, constants, sji,basloc,dbsloc,vplm,vcos,vsin)
+
+                ! assemble the contribution
+                a = zero
+                tt = one/(tji)
+                do l = 0, params % lmax
+                    ind = l*l + l + 1
+                    fl = dble(l)
+                    fcl = - tt*fourpi*fl/(two*fl + one)
+                    do m = -l, l
+                        fac = fcl*g(ind+m,isph)
+                        b = (fl + one)*basloc(ind+m)/(params % rsph(isph)*tji)
+
+                        ! apply the jacobian to grad y
+                        va(1) = sjac(1,1)*dbsloc(1,ind+m) + &
+                            & sjac(1,2)*dbsloc(2,ind+m) + sjac(1,3)*dbsloc(3,ind+m)
+                        va(2) = sjac(2,1)*dbsloc(1,ind+m) + &
+                            & sjac(2,2)*dbsloc(2,ind+m) + sjac(2,3)*dbsloc(3,ind+m)
+                        va(3) = sjac(3,1)*dbsloc(1,ind+m) + &
+                            & sjac(3,2)*dbsloc(2,ind+m) + sjac(3,3)*dbsloc(3,ind+m)
+                        a(1) = a(1) + fac*(sji(1)*b + va(1))
+                        a(2) = a(2) + fac*(sji(2)*b + va(2))
+                        a(3) = a(3) + fac*(sji(3)*b + va(3))
+                    end do
+                    tt = tt/tji
+                end do
+                fac = constants % ui(its,jsph)*constants % wgrid(its)*ygrid(its,jsph)
+                fx(1) = fx(1) - fac*a(1)
+                fx(2) = fx(2) - fac*a(2)
+                fx(3) = fx(3) - fac*a(3)
+            end if
+        end do
+    end do
+
+    ! ka contribution
+    do its = 1, params % ngrid
+        cx = params % csph(1,isph) + params % rsph(isph)*constants % cgrid(1,its)
+        cy = params % csph(2,isph) + params % rsph(isph)*constants % cgrid(2,its)
+        cz = params % csph(3,isph) + params % rsph(isph)*constants % cgrid(3,its)
+        a = zero
+
+        ! iterate on all the spheres except isph
+        do ksph = 1, params % nsph
+            if (constants % ui(its,isph).gt.zero .and. ksph.ne.isph) then
+                ! geometrical stuff
+                vik(1) = cx - params % csph(1,ksph)
+                vik(2) = cy - params % csph(2,ksph)
+                vik(3) = cz - params % csph(3,ksph)
+                !vvik = sqrt(vik(1)*vik(1) + vik(2)*vik(2) + & 
+                !    & vik(3)*vik(3))
+                vvik = dnrm2(3, vik, 1)
+                tik = vvik/params % rsph(ksph)
+                qik = one/vvik
+                sik = vik/vvik
+
+                ! build the jacobian of sik
+                sjac = zero
+                sjac(1,1) = one
+                sjac(2,2) = one
+                sjac(3,3) = one
+                do icomp = 1, 3
+                    do jcomp = 1, 3
+                    sjac(icomp,jcomp) = qik*(sjac(icomp,jcomp) &
+                        & - sik(icomp)*sik(jcomp))
+                    end do
+                end do
+
+                ! if we are in the switching region, recover grad_i u_i
+                vb = zero
+                if (constants % ui(its,isph).lt.one) then
+                    vb(1) = constants % zi(1,its,isph)
+                    vb(2) = constants % zi(2,its,isph)
+                    vb(3) = constants % zi(3,its,isph)
+                end if
+
+                ! assemble the local basis and its gradient
+                !call dbasis(sik,basloc,dbsloc,vplm,vcos,vsin)
+                call dbasis(params, constants, sik,basloc,dbsloc,vplm,vcos,vsin)
+
+                ! assemble the contribution
+                tt = one/(tik)
+                do l = 0, params % lmax
+                    ind = l*l + l + 1
+                    fl = dble(l)
+                    fcl = - tt*fourpi*fl/(two*fl + one)
+                        do m = -l, l
+                        fac = fcl*g(ind+m,ksph)
+                        fac = - fac*basloc(ind+m)
+                        a(1) = a(1) + fac*vb(1)
+                        a(2) = a(2) + fac*vb(2) 
+                        a(3) = a(3) + fac*vb(3)
+
+                        fac = constants % ui(its,isph)*fcl*g(ind+m,ksph)
+                        b = - (fl + one)*basloc(ind+m)/(params % rsph(ksph)*tik)
+
+                        ! apply the jacobian to grad y
+                        va(1) = sjac(1,1)*dbsloc(1,ind+m) + &
+                            & sjac(1,2)*dbsloc(2,ind+m) + sjac(1,3)*dbsloc(3,ind+m)
+                        va(2) = sjac(2,1)*dbsloc(1,ind+m) + &
+                            & sjac(2,2)*dbsloc(2,ind+m) + sjac(2,3)*dbsloc(3,ind+m)
+                        va(3) = sjac(3,1)*dbsloc(1,ind+m) + &
+                            & sjac(3,2)*dbsloc(2,ind+m) + sjac(3,3)*dbsloc(3,ind+m)
+                        a(1) = a(1) + fac*(sik(1)*b + va(1))
+                        a(2) = a(2) + fac*(sik(2)*b + va(2))
+                        a(3) = a(3) + fac*(sik(3)*b + va(3))
+                    end do
+                    tt = tt/tik
+                end do
+            end if
+        end do
+        fac = constants % wgrid(its)*ygrid(its,isph)
+        fx(1) = fx(1) - fac*a(1)
+        fx(2) = fx(2) - fac*a(2)
+        fx(3) = fx(3) - fac*a(3)
+    end do
+end subroutine gradr_sph
+
+!> Compute the ddPCM matrix gradient using FMMS (2 matvecs)
+subroutine gradr_fmm(params, constants, workspace, g, ygrid, fx)
+    implicit none
+    ! Inputs
+    type(ddx_params_type), intent(in) :: params
+    type(ddx_constants_type), intent(in) :: constants
+    real(dp), intent(in) :: g(constants % nbasis, params % nsph), &
+        & ygrid(params % ngrid, params % nsph)
+    ! Temporaries
+    type(ddx_workspace_type), intent(inout) :: workspace
+    ! Output
+    real(dp), intent(out) :: fx(3, params % nsph)
+    ! Local variables
+    integer :: indl, indl1, l, isph, igrid, ik, ksph, &
+        & jsph, jsph_node
+    integer :: inear, inode, jnode
+    real(dp) :: gg, c(3), vki(3), vvki, tki, gg3(3), tmp_gg, tmp_c(3)
+    real(dp) :: tlow, thigh
+    real(dp), dimension(3, 3) :: zx_coord_transform, zy_coord_transform
+    real(dp), external :: ddot, dnrm2
+    real(dp) :: work(params % lmax+2)
+    !real(dp) :: l2g(params % ngrid, params % nsph)
+    zx_coord_transform = 0
+    zx_coord_transform(3, 2) = 1
+    zx_coord_transform(2, 3) = 1
+    zx_coord_transform(1, 1) = 1
+    zy_coord_transform = 0
+    zy_coord_transform(1, 2) = 1
+    zy_coord_transform(2, 1) = 1
+    zy_coord_transform(3, 3) = 1
+    tlow  = one - pt5*(one - params % se)*params % eta
+    thigh = one + pt5*(one + params % se)*params % eta
+    fx = zero
+    !! Scale input harmonics at first
+    workspace % tmp_sph(1, :) = zero
+    indl = 2
+    do l = 1, params % lmax
+        indl1 = (l+1)**2
+        workspace % tmp_sph(indl:indl1, :) = l * g(indl:indl1, :)
+        indl = indl1 + 1
+    end do
+    !! Compute gradient of M2M of tmp_sph harmonics at the origin and store it
+    !! in tmp_sph_grad. tmp_sph_grad(:, 1, :), tmp_sph_grad(:, 2, :) and
+    !! tmp_sph_grad(:, 3, :) correspond to the OX, OY and OZ axes. Variable
+    !! tmp_sph2 is a temporary workspace here.
+    call tree_grad_m2m(params, constants, workspace % tmp_sph, &
+        & workspace % tmp_sph_grad, workspace % tmp_sph2)
+    !! Adjoint full FMM matvec to get output multipole expansions from input
+    !! external grid points. It is used to compute R_i^B fast as a contraction
+    !! of a gradient stored in tmp_sph_grad and a result of adjoint matvec.
+    ! Adjoint integration from spherical harmonics to grid points is not needed
+    ! here as ygrid already contains grid values, we just need to scale it by
+    ! weights of grid points
+    do isph = 1, params % nsph
+        workspace % tmp_grid(:, isph) = ygrid(:, isph) * &
+            & constants % wgrid(:) * constants % ui(:, isph)
+    end do
+    ! Adjoint FMM with output tmp_sph2(:, :) which stores coefficients of
+    ! harmonics of degree up to lmax+1
+    call tree_m2p_adj(params, constants, params % lmax+1, one, &
+        & workspace % tmp_grid, zero, workspace % tmp_sph2)
+    call tree_l2p_adj(params, constants, one, workspace % tmp_grid, zero, &
+        & workspace % tmp_node_l, workspace % tmp_sph_l)
+    call tree_l2l_rotation_adj(params, constants, workspace % tmp_node_l)
+    call tree_m2l_rotation_adj(params, constants, workspace % tmp_node_l, &
+        & workspace % tmp_node_m)
+    call tree_m2m_rotation_adj(params, constants, workspace % tmp_node_m)
+    ! Properly load adjoint multipole harmonics into tmp_sph2 that holds
+    ! harmonics of a degree up to lmax+1
+    if(params % lmax+1 .lt. params % pm) then
+        do isph = 1, params % nsph
+            inode = constants % snode(isph)
+            workspace % tmp_sph2(:, isph) = workspace % tmp_sph2(:, isph) + &
+                & workspace % tmp_node_m(1:constants % grad_nbasis, inode)
+        end do
+    else
+        indl = (params % pm+1)**2
+        do isph = 1, params % nsph
+            inode = constants % snode(isph)
+            workspace % tmp_sph2(1:indl, isph) = &
+                & workspace % tmp_sph2(1:indl, isph) + &
+                & workspace % tmp_node_m(:, inode)
+        end do
+    end if
+    ! Compute second term of R_i^B as a contraction
+    do isph = 1, params % nsph
+        call dgemv('T', constants % grad_nbasis, 3, one, &
+            & workspace % tmp_sph_grad(1, 1, isph), constants % grad_nbasis, &
+            & workspace % tmp_sph2(1, isph), 1, zero, fx(1, isph), 1)
+    end do
+    !! Direct far-field FMM matvec to get output local expansions from input
+    !! multipole expansions. It will be used in R_i^A.
+    !! As of now I compute potential at all external grid points, improved
+    !! version shall only compute it at external points in a switch region
+    ! Load input harmonics into tree data
+    if(params % lmax .lt. params % pm) then
+        do isph = 1, params % nsph
+            inode = constants % snode(isph)
+            workspace % tmp_node_m(:constants % nbasis, inode) = &
+                & workspace % tmp_sph(:, isph)
+            workspace % tmp_node_m(constants % nbasis+1:, inode) = zero
+        end do
+    else
+        indl = (params % pm+1)**2
+        do isph = 1, params % nsph
+            inode = constants % snode(isph)
+            workspace % tmp_node_m(:, inode) = workspace % tmp_sph(1:indl, isph)
+        end do
+    end if
+    ! Perform direct FMM matvec to all external grid points
+    call tree_m2m_rotation(params, constants, workspace % tmp_node_m)
+    call tree_m2l_rotation(params, constants, workspace % tmp_node_m, &
+        & workspace % tmp_node_l)
+    call tree_l2l_rotation(params, constants, workspace % tmp_node_l)
+    call tree_l2p(params, constants, one, workspace % tmp_node_l, zero, &
+        & workspace % tmp_grid, workspace % tmp_sph_l)
+    call tree_m2p(params, constants, params % lmax, one, &
+        & workspace % tmp_sph, one, workspace % tmp_grid)
+    !! Compute gradients of L2L if pl > 0
+    if (params % pl .gt. 0) then
+        call tree_grad_l2l(params, constants, workspace % tmp_node_l, &
+            & workspace % tmp_sph_l_grad, workspace % tmp_sph_l)
+    end if
+    !! Diagonal update of computed grid values, that is needed for R^C, a part
+    !! of R^A and a part of R^B
+    call dgemm('T', 'N', params % ngrid, params % nsph, constants % nbasis, &
+        & pt5, constants % vgrid2, constants % vgrid_nbasis, g, &
+        & constants % nbasis, -one, workspace % tmp_grid, params % ngrid)
+    !! Scale temporary grid points by corresponding Lebedev weights and ygrid
+    do igrid = 1, params % ngrid
+        do isph = 1, params % nsph
+            workspace % tmp_grid(igrid, isph) = &
+                & workspace % tmp_grid(igrid, isph) *  constants % wgrid(igrid) * &
+                & ygrid(igrid, isph)
+        end do
+    end do
+    !! Compute all terms of grad_i(R). The second term of R_i^B is already
+    !! taken into account and the first term is computed together with R_i^C.
+    do isph = 1, params % nsph
+        do igrid = 1, params % ngrid
+            ! Loop over all neighbouring spheres
+            do ik = constants % inl(isph), constants % inl(isph+1) - 1
+                ksph = constants % nl(ik)
+                ! Only consider external grid points
+                if(constants % ui(igrid, ksph) .eq. zero) cycle
+                ! build geometrical quantities
+                c = params % csph(:, ksph) + &
+                    & params % rsph(ksph)*constants % cgrid(:, igrid)
+                vki = c - params % csph(:, isph)
+                !vvki = sqrt(vki(1)*vki(1) + vki(2)*vki(2) + &
+                !    & vki(3)*vki(3))
+                vvki = dnrm2(3, vki, 1)
+                tki = vvki / params % rsph(isph)
+                ! Only consider such points where grad U is non-zero
+                if((tki.le.tlow) .or. (tki.ge.thigh)) cycle
+                ! This is entire R^C and the first R^B component (grad_i of U
+                ! of a sum of R_kj for index inequality j!=k)
+                ! Indexes k and j are flipped compared to the paper
+                gg = workspace % tmp_grid(igrid, ksph)
+                ! Compute grad_i component of forces using precomputed
+                ! potential gg
+                !fx(:, isph) = fx(:, isph) - &
+                !    & dfsw(tki, params % se, params % eta)/ &
+                !    & params % rsph(isph)*constants % wgrid(igrid)*gg* &
+                !    & ygrid(igrid, ksph)*(vki/vvki)
+                fx(:, isph) = fx(:, isph) - &
+                    & dfsw(tki, params % se, params % eta)/ &
+                    & params % rsph(isph)*gg*(vki/vvki)
+            end do
+            ! contribution from the sphere itself
+            if((constants % ui(igrid,isph).gt.zero) .and. &
+                & (constants % ui(igrid,isph).lt.one)) then
+                ! R^A component (grad_i of U of a sum of R_ij for index
+                ! inequality j!=i)
+                ! Indexes k and j are flipped compared to the paper
+                gg = workspace % tmp_grid(igrid, isph)
+                ! Compute grad_i component of forces using precomputed
+                ! potential gg
+                !fx(:, isph) = fx(:, isph) + constants % wgrid(igrid)*gg* &
+                !    & ygrid(igrid, isph)*constants % zi(:, igrid, isph)
+                fx(:, isph) = fx(:, isph) + gg*constants % zi(:, igrid, isph)
+            end if
+            if (constants % ui(igrid, isph) .gt. zero) then
+                ! Another R^A component (grad_i of potential of a sum of R_ij
+                ! for index inequality j!=i)
+                ! Indexes k and j are flipped compared to the paper
+                ! In case pl=0 MKL does not make gg3 zero reusing old value of
+                ! gg3, so we have to clear it manually
+                gg3 = zero
+                call dgemv('T', params % pl**2, 3, one, &
+                    & workspace % tmp_sph_l_grad(1, 1, isph), &
+                    & (params % pl+1)**2, constants % vgrid2(1, igrid), 1, &
+                    & zero, gg3, 1)
+                ! Gradient of the near-field potential is a gradient of
+                ! multipole expansion
+                inode = constants % snode(isph)
+                do inear = constants % snear(inode), constants % snear(inode+1)-1
+                    jnode = constants % near(inear)
+                    do jsph_node = constants % cluster(1, jnode), &
+                        & constants % cluster(2, jnode)
+                        jsph = constants % order(jsph_node)
+                        if (isph .eq. jsph) cycle
+                        c = params % csph(:, isph) + &
+                            & params % rsph(isph)*constants % cgrid(:, igrid)
+                        tmp_c = c - params % csph(:, jsph)
+                        call fmm_m2p_work(tmp_c, &
+                            & params % rsph(jsph), params % lmax+1, &
+                            & constants % vscales_rel, one, &
+                            & workspace % tmp_sph_grad(:, 1, jsph), zero, &
+                            & tmp_gg, work)
+                        gg3(1) = gg3(1) + tmp_gg
+                        call fmm_m2p_work(tmp_c, &
+                            & params % rsph(jsph), params % lmax+1, &
+                            & constants % vscales_rel, one, &
+                            & workspace % tmp_sph_grad(:, 2, jsph), zero, &
+                            & tmp_gg, work)
+                        gg3(2) = gg3(2) + tmp_gg
+                        call fmm_m2p_work(tmp_c, &
+                            & params % rsph(jsph), params % lmax+1, &
+                            & constants % vscales_rel, one, &
+                            & workspace % tmp_sph_grad(:, 3, jsph), zero, &
+                            & tmp_gg, work)
+                        gg3(3) = gg3(3) + tmp_gg
+                    end do
+                end do
+                ! Accumulate all computed forces
+                fx(:, isph) = fx(:, isph) - constants % wgrid(igrid)*gg3* &
+                    & ygrid(igrid, isph)*constants % ui(igrid, isph)
+            end if
+        end do
+    end do
+end subroutine gradr_fmm
+
+!> Gradient of the ddPCM matrix
+subroutine gradr(params, constants, workspace, g, ygrid, fx)
+    implicit none
+    ! Inputs
+    type(ddx_params_type), intent(in) :: params
+    type(ddx_constants_type), intent(in) :: constants
+    real(dp), intent(in) :: g(constants % nbasis, params % nsph), &
+        & ygrid(params % ngrid, params % nsph)
+    ! Temporaries
+    type(ddx_workspace_type), intent(inout) :: workspace
+    ! Output
+    real(dp), intent(out) :: fx(3, params % nsph)
+    ! Check which gradr to execute
+    if (params % fmm .eq. 1) then
+        call gradr_fmm(params, constants, workspace, g, ygrid, fx)
+    else
+        call gradr_dense(params, constants, workspace, g, ygrid, fx)
+    end if
+end subroutine gradr
+
+!> Gradient of the ddPCM matrix using N^2 code
+subroutine gradr_dense(params, constants, workspace, g, ygrid, fx)
+    implicit none
+    ! Inputs
+    type(ddx_params_type), intent(in) :: params
+    type(ddx_constants_type), intent(in) :: constants
+    real(dp), intent(in) :: g(constants % nbasis, params % nsph), &
+        & ygrid(params % ngrid, params % nsph)
+    ! Temporaries
+    type(ddx_workspace_type), intent(inout) :: workspace
+    ! Output
+    real(dp), intent(out) :: fx(3, params % nsph)
+    ! Local variables
+    integer :: isph
+    ! Simply cycle over all spheres
+    do isph = 1, params % nsph
+        call gradr_sph(params, constants, isph, workspace % tmp_vplm, &
+            & workspace % tmp_vcos, workspace % tmp_vsin, &
+            & workspace % tmp_vylm, workspace % tmp_vdylm, &
+            & g, ygrid, fx(:, isph))
+    end do
+end subroutine gradr_dense
+
+
 end module ddx_gradients

--- a/src/ddx_gradients.f90
+++ b/src/ddx_gradients.f90
@@ -282,8 +282,9 @@ end subroutine contract_grad_B
 !! @param[inout] force     : Force
 !! @param[out] diff_re     : epsilon_1/epsilon_2 * l'/r_j[Xr]_jl'm'
 !!                         - (i'_l'(r_j)/i_l'(r_j))[Xe]_jl'm'
+!! @param[inout] error: ddX error
 subroutine contract_grad_C(params, constants, workspace, Xr, Xe, Xadj_r_sgrid, &
-    & Xadj_e_sgrid, Xadj_r, Xadj_e, force, diff_re)
+    & Xadj_e_sgrid, Xadj_r, Xadj_e, force, diff_re, error)
     !! input/output
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
@@ -293,13 +294,22 @@ subroutine contract_grad_C(params, constants, workspace, Xr, Xe, Xadj_r_sgrid, &
     real(dp), dimension(constants % nbasis, params % nsph), intent(in) :: Xadj_r, Xadj_e
     real(dp), dimension(3, params % nsph), intent(inout) :: force
     real(dp), dimension(constants % nbasis, params % nsph), intent(out) :: diff_re
+    type(ddx_error_type), intent(inout) :: error
 
     call contract_grad_C_worker2(params, constants, workspace, Xr, Xe, Xadj_r_sgrid, &
-        & Xadj_e_sgrid, Xadj_r, Xadj_e, force, diff_re)
-    if (workspace % error_flag .eq. 1) return
+        & Xadj_e_sgrid, Xadj_r, Xadj_e, force, diff_re, error)
+    if (error % flag .ne. 0) then
+        call update_error(error, &
+            & "contract_grad_C_worker2 returned an error, exiting")
+        return
+    end if
     call contract_grad_C_worker1(params, constants, workspace, Xadj_r_sgrid, &
-        & Xadj_e_sgrid, diff_re, force)
-    if (workspace % error_flag .eq. 1) return
+        & Xadj_e_sgrid, diff_re, force, error)
+    if (error % flag .ne. 0) then
+        call update_error(error, &
+            & "contract_grad_C_worker1 returned an error, exiting")
+        return
+    end if
 
 end subroutine contract_grad_C
 
@@ -313,8 +323,9 @@ end subroutine contract_grad_C
 !! @param[in]  normal_hessian_cav : Normal of the Hessian evaluated at cavity points
 !! @param[in]  icav_g             : Index of outside cavity point
 !! @param[out] force              : Force
+!! @param[inout] error: ddX error
 subroutine contract_grad_f(params, constants, workspace, sol_adj, sol_sgrid, &
-    & gradpsi, normal_hessian_cav, force, state)
+    & gradpsi, normal_hessian_cav, force, state, error)
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_workspace_type), intent(inout) :: workspace
@@ -324,13 +335,23 @@ subroutine contract_grad_f(params, constants, workspace, sol_adj, sol_sgrid, &
     real(dp), dimension(3, constants % ncav), intent(in) :: gradpsi
     real(dp), dimension(3, constants % ncav), intent(in) :: normal_hessian_cav
     real(dp), dimension(3, params % nsph), intent(inout) :: force
+    type(ddx_error_type), intent(inout) :: error
 
     call contract_grad_f_worker1(params, constants, workspace, sol_adj, sol_sgrid, &
-        & gradpsi, force)
-    if (workspace % error_flag .eq. 1) return
+        & gradpsi, force, error)
+    if (error % flag .ne. 0) then
+        call update_error(error, &
+            & "contract_grad_f_worker1 returned an error, exiting")
+        return
+    end if
+
     call contract_grad_f_worker2(params, constants, workspace, gradpsi, &
-        & normal_hessian_cav, force, state)
-    if (workspace % error_flag .eq. 1) return
+        & normal_hessian_cav, force, state, error)
+    if (error % flag .ne. 0) then
+        call update_error(error, &
+            & "contract_grad_f_worker2 returned an error, exiting")
+        return
+    end if
 
 end subroutine contract_grad_f
 
@@ -559,8 +580,9 @@ end subroutine contract_gradi_Bji
 !! @param[in]  Xadj_e_sgrid : Adjoint HSP solution evaluated at grid point
 !! @param[in]  diff_re      : l'/r_j[Xr]_jl'm' -(i'_l'(r_j)/i_l'(r_j))[Xe]_jl'm'
 !! @param[out] force        : Force
+!! @param[inout] error: ddX error
 subroutine contract_grad_C_worker1(params, constants, workspace, Xadj_r_sgrid, &
-    & Xadj_e_sgrid, diff_re, force)
+    & Xadj_e_sgrid, diff_re, force, error)
     !! Inputs
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
@@ -570,6 +592,7 @@ subroutine contract_grad_C_worker1(params, constants, workspace, Xadj_r_sgrid, &
     real(dp), dimension(params % ngrid, params % nsph), intent(in) :: &
         & Xadj_r_sgrid, Xadj_e_sgrid
     real(dp), dimension(3, params % nsph), intent(inout) :: force
+    type(ddx_error_type), intent(inout) :: error
     ! Local variable
     ! igrid0: Index for grid point n0
     integer :: isph, jsph, igrid, l0, m0, ind0, igrid0, icav, &
@@ -610,8 +633,7 @@ subroutine contract_grad_C_worker1(params, constants, workspace, Xadj_r_sgrid, &
         & phi_n_e(params % ngrid, params % nsph), &
         & diff_re_sgrid(params % ngrid, params % nsph), stat=istat)
     if (istat.ne.0) then
-        workspace % error_flag = 1
-        workspace % error_message = "allocation error in ddx_contract_grad_C_worker1"
+        call update_error(error, "allocation error in ddx_contract_grad_C_worker1")
         return
     end if
 !
@@ -633,8 +655,7 @@ subroutine contract_grad_C_worker1(params, constants, workspace, Xadj_r_sgrid, &
         allocate(coefY_d(constants % ncav, params % ngrid, params % nsph), &
             & stat=istat)
         if (istat.ne.0) then
-            workspace % error_flag = 1
-            workspace % error_message = "allocation error in fmm ddx_contract_grad_C_worker1"
+            call update_error(error, "allocation error in fmm ddx_contract_grad_C_worker1")
             return
         end if
         coefY_d = zero
@@ -810,15 +831,13 @@ subroutine contract_grad_C_worker1(params, constants, workspace, Xadj_r_sgrid, &
 
     deallocate(phi_n_r, phi_n_e, diff_re_sgrid, stat=istat)
     if (istat.ne.0) then
-        workspace % error_flag = 1
-        workspace % error_message = "deallocation error in ddx_contract_grad_C_worker1"
+        call update_error(error, "deallocation error in ddx_contract_grad_C_worker1")
         return
     end if
     if (allocated(coefY_d)) then
         deallocate(coefY_d, stat=istat)
         if (istat.ne.0) then
-            workspace % error_flag = 1
-            workspace % error_message = "deallocation error in ddx_contract_grad_C_worker1"
+            call update_error(error, "deallocation error in ddx_contract_grad_C_worker1")
             return
         end if
     end if
@@ -842,8 +861,9 @@ end subroutine contract_grad_C_worker1
 !! @param[inout] force     : Force
 !! @param[out] diff_re     : epsilon_1/epsilon_2 * l'/r_j[Xr]_jl'm'
 !!                         - (i'_l'(r_j)/i_l'(r_j))[Xe]_jl'm'
+!! @param[inout] error: ddX error
 subroutine contract_grad_C_worker2(params, constants, workspace, Xr, Xe, &
-        & Xadj_r_sgrid, Xadj_e_sgrid, Xadj_r, Xadj_e, force, diff_re)
+        & Xadj_r_sgrid, Xadj_e_sgrid, Xadj_r, Xadj_e, force, diff_re, error)
     !! input/output
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
@@ -856,6 +876,7 @@ subroutine contract_grad_C_worker2(params, constants, workspace, Xr, Xe, &
     real(dp), dimension(3, params % nsph), intent(inout) :: force
     real(dp), dimension(constants % nbasis, params % nsph), intent(out) :: &
         & diff_re
+    type(ddx_error_type), intent(inout) :: error
     real(dp), external :: dnrm2
     ! Local variable
     integer :: isph, jsph, igrid, l, m, ind, l0, ind0, icav, indl, inode, &
@@ -884,8 +905,7 @@ subroutine contract_grad_C_worker2(params, constants, workspace, Xr, Xe, &
         & diff1_grad((constants % lmax0+2)**2, 3, params % nsph), &
         & l2l_grad((params % pl+2)**2, 3, params % nsph), stat=istat)
     if (istat.ne.0) then
-        workspace % error_flag = 1
-        workspace % error_message = "allocation error in ddx_contract_grad_C_worker2"
+        call update_error(error, "allocation error in ddx_contract_grad_C_worker2")
         return
     end if
 
@@ -1197,8 +1217,7 @@ subroutine contract_grad_C_worker2(params, constants, workspace, Xr, Xe, &
     deallocate(diff_ep_dim3, phi_in, sum_dim3, diff1_grad, l2l_grad, &
         & diff0, diff1, stat=istat)
     if (istat.ne.0) then
-        workspace % error_flag = 1
-        workspace % error_message = "deallocation error in ddx_contract_grad_C_worker2"
+        call update_error(error, "deallocation error in ddx_contract_grad_C_worker2")
         return
     end if
 end subroutine contract_grad_C_worker2
@@ -1215,8 +1234,9 @@ end subroutine contract_grad_C_worker2
 !! @param[in] sol_adj      : Adjoint solution
 !! @param[in] gradpsi      : Gradient of Psi_0
 !! @param[inout] force     : Force
+!! @param[inout] error: ddX error
 subroutine contract_grad_f_worker1(params, constants, workspace, sol_adj, sol_sgrid, &
-    & gradpsi, force)
+    & gradpsi, force, error)
     ! input/output
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
@@ -1226,6 +1246,7 @@ subroutine contract_grad_f_worker1(params, constants, workspace, sol_adj, sol_sg
     real(dp), dimension(params % ngrid, params % nsph), intent(in) :: sol_sgrid
     real(dp), dimension(3, constants % ncav), intent(in) :: gradpsi
     real(dp), dimension(3, params % nsph), intent(inout) :: force
+    type(ddx_error_type), intent(inout) :: error
 
     ! local
     real(dp), external :: dnrm2
@@ -1264,8 +1285,7 @@ subroutine contract_grad_f_worker1(params, constants, workspace, sol_adj, sol_sg
         & l2l_grad((params % pl+2)**2, 3, params % nsph), &
         & diff0(constants % nbasis0, params % nsph), stat=istat)
     if (istat.ne.0) then
-        workspace % error_flag = 1
-        workspace % error_message = "allocation error in ddx_grad_f_worker1"
+        call update_error(error, "allocation error in ddx_grad_f_worker1")
         return
     end if
 
@@ -1547,15 +1567,15 @@ subroutine contract_grad_f_worker1(params, constants, workspace, sol_adj, sol_sg
     deallocate(phi_in, diff_ep_dim3, sum_dim3, c0_d, c0_d1, &
           & c0_d1_grad, sum_Sjin, l2l_grad, diff0, stat=istat)
     if (istat.ne.0) then
-        workspace % error_flag = 1
-        workspace % error_message = "deallocation error in ddx_grad_f_worker1"
+        call update_error(error, "deallocation error in ddx_grad_f_worker1")
         return
     end if
 
 end subroutine contract_grad_f_worker1
 
+!! @param[inout] error: ddX error
 subroutine contract_grad_f_worker2(params, constants, workspace, &
-        & gradpsi, normal_hessian_cav, force, state)
+        & gradpsi, normal_hessian_cav, force, state, error)
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_workspace_type), intent(inout) :: workspace
@@ -1563,6 +1583,7 @@ subroutine contract_grad_f_worker2(params, constants, workspace, &
         & normal_hessian_cav(3, constants % ncav)
     real(dp), intent(inout) :: force(3, params % nsph)
     type(ddx_state_type), intent(inout) :: state
+    type(ddx_error_type), intent(inout) :: error
 
     integer :: icav, isph, igrid, istat
     real(dp) :: nderpsi
@@ -1570,8 +1591,7 @@ subroutine contract_grad_f_worker2(params, constants, workspace, &
 
     allocate(gradpsi_grid(params % ngrid, params % nsph), stat=istat)
     if (istat.ne.0) then
-        workspace % error_flag = 1
-        workspace % error_message = "allocation error in ddx_grad_f_worker2"
+        call update_error(error, "allocation error in ddx_grad_f_worker2")
         return
     end if
 
@@ -1603,8 +1623,7 @@ subroutine contract_grad_f_worker2(params, constants, workspace, &
 
     deallocate(gradpsi_grid, stat=istat)
     if (istat.ne.0) then
-        workspace % error_flag = 1
-        workspace % error_message = "deallocation error in ddx_grad_f_worker2"
+        call update_error(error, "deallocation error in ddx_grad_f_worker2")
         return
     end if
 

--- a/src/ddx_harmonics.f90
+++ b/src/ddx_harmonics.f90
@@ -4623,7 +4623,6 @@ subroutine fmm_m2m_bessel_ztranslate_work(z, src_sk, dst_sk, p, vscales, &
         end if
     ! If harmonics are located at the same point
     else
-        stop 'this code needs to be checked'
         r1 = zero
         ! Overwrite output if beta is zero
         if (beta .eq. zero) then
@@ -4863,7 +4862,6 @@ subroutine fmm_m2m_bessel_ztranslate_adj_work(z, src_sk, dst_sk, p, vscales, &
         end if
     ! If harmonics are located at the same point
     else
-        stop 'this code needs to be checked'
         r1 = zero
         ! Overwrite output if beta is zero
         if (beta .eq. zero) then
@@ -6562,7 +6560,6 @@ subroutine fmm_l2l_bessel_ztranslate_work(z, src_si, dst_si, p, vscales, &
         end if
     ! If harmonics are located at the same point
     else
-        stop 'this code needs to be checked'
         r1 = zero
         ! Overwrite output if beta is zero
         if (beta .eq. zero) then
@@ -6803,7 +6800,6 @@ subroutine fmm_l2l_bessel_ztranslate_adj_work(z, src_si, dst_si, p, vscales, &
         end if
     ! If harmonics are located at the same point
     else
-        stop 'this code needs to be checked'
         r1 = zero
         ! Overwrite output if beta is zero
         if (beta .eq. zero) then
@@ -8637,7 +8633,6 @@ subroutine fmm_m2l_bessel_ztranslate_work(z, src_sk, dst_si, p, vscales, &
         end if
     ! If harmonics are located at the same point
     else
-        stop 'this code needs to be checked'
         r1 = zero
         ! Overwrite output if beta is zero
         if (beta .eq. zero) then
@@ -8877,7 +8872,6 @@ subroutine fmm_m2l_bessel_ztranslate_adj_work(z, src_sk, dst_si, p, vscales, &
         end if
     ! If harmonics are located at the same point
     else
-        stop 'this code needs to be checked'
         r1 = zero
         ! Overwrite output if beta is zero
         if (beta .eq. zero) then

--- a/src/ddx_lpb.f90
+++ b/src/ddx_lpb.f90
@@ -54,20 +54,20 @@ subroutine ddlpb(params, constants, workspace, state, phi_cav, e_cav, &
     call ddlpb_setup(params, constants, workspace, state, phi_cav, &
         & e_cav, psi, error)
     if (error % flag .ne. 0) then
-        call update_error(error,
-            "ddlpb: ddlpb_setup returned an error, exiting")
+        call update_error(error, &
+            & "ddlpb: ddlpb_setup returned an error, exiting")
         return
     end if
     call ddlpb_guess(params, constants, workspace, state, tol, error)
     if (error % flag .ne. 0) then
-        call update_error(error,
-            "ddlpb: ddlpb_guess returned an error, exiting")
+        call update_error(error, &
+            & "ddlpb: ddlpb_guess returned an error, exiting")
         return
     end if
     call ddlpb_solve(params, constants, workspace, state, tol, error)
     if (error % flag .ne. 0) then
-        call update_error(error,
-            "ddlpb: ddlpb_solve returned an error, exiting")
+        call update_error(error, &
+            & "ddlpb: ddlpb_solve returned an error, exiting")
         return
     end if
 
@@ -78,14 +78,14 @@ subroutine ddlpb(params, constants, workspace, state, phi_cav, e_cav, &
     if(params % force .eq. 1) then
         call ddlpb_guess_adjoint(params, constants, workspace, state, tol, error)
         if (error % flag .ne. 0) then
-            call update_error(error,
-                "ddlpb: ddlpb_guess_adjoint returned an error, exiting")
+            call update_error(error, &
+                & "ddlpb: ddlpb_guess_adjoint returned an error, exiting")
             return
         end if
         call ddlpb_solve_adjoint(params, constants, workspace, state, tol, error)
         if (error % flag .ne. 0) then
-            call update_error(error,
-                "ddlpb: ddlpb_solve_adjoint returned an error, exiting")
+            call update_error(error, &
+                & "ddlpb: ddlpb_solve_adjoint returned an error, exiting")
             return
         end if
         call ddlpb_solvation_force_terms(params, constants, workspace, &

--- a/src/ddx_lpb.f90
+++ b/src/ddx_lpb.f90
@@ -409,7 +409,12 @@ subroutine ddlpb_solvation_force_terms(params, constants, workspace, &
     call contract_grad_C(params, constants, workspace, state % x_lpb(:,:,1), &
         & state % x_lpb(:,:,2), state % x_adj_r_grid, state % x_adj_e_grid, &
         & state % x_adj_lpb(:,:,1), state % x_adj_lpb(:,:,2), force, &
-        & diff_re)
+        & diff_re, error)
+    if (error % flag .ne. 0) then
+        call update_error(error, &
+            & "contract_grad_C returned an error, exiting")
+        return
+    end if
     ! Computation of G0 continued
 
     ! NOTE: contract_grad_U returns a positive summation
@@ -432,8 +437,12 @@ subroutine ddlpb_solvation_force_terms(params, constants, workspace, &
     call contract_grad_f(params, constants, workspace, &
         & state % x_adj_lpb(:,:,1) + state % x_adj_lpb(:,:,2), &
         & state % x_adj_re_grid, state % gradphi_cav, &
-        & normal_hessian_cav, force, state)
-    if (workspace % error_flag .eq. 1) return
+        & normal_hessian_cav, force, state, error)
+    if (error % flag .ne. 0) then
+        call update_error(error, &
+            & "contract_grad_f returned an error, exiting")
+        return
+    end if
 
     force = pt5*force
 

--- a/src/ddx_lpb.f90
+++ b/src/ddx_lpb.f90
@@ -57,7 +57,7 @@ subroutine ddlpb(params, constants, workspace, state, phi_cav, e_cav, &
     call ddlpb_solve(params, constants, workspace, state, tol, error)
 
     ! Compute the solvation energy
-    call ddlpb_energy(constants, state, esolv)
+    call ddlpb_energy(constants, state, esolv, error)
 
     ! Get forces if needed
     if(params % force .eq. 1) then
@@ -148,11 +148,13 @@ end subroutine ddlpb_setup
 !! @param[in] constants: Precomputed constants
 !! @param[in] state: ddx state (contains solutions and RHSs)
 !! @param[out] esolv: resulting energy
+!! @param[inout] error: ddX error
 !!
-subroutine ddlpb_energy(constants, state, esolv)
+subroutine ddlpb_energy(constants, state, esolv, error)
     implicit none
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_state_type), intent(in) :: state
+    type(ddx_error_type), intent(inout) :: error
     real(dp), intent(out) :: esolv
     real(dp), external :: ddot
     esolv = pt5*ddot(constants % n, state % x_lpb(:,:,1), 1, state % psi, 1)

--- a/src/ddx_lpb.f90
+++ b/src/ddx_lpb.f90
@@ -53,8 +53,23 @@ subroutine ddlpb(params, constants, workspace, state, phi_cav, e_cav, &
 
     call ddlpb_setup(params, constants, workspace, state, phi_cav, &
         & e_cav, psi, error)
+    if (error % flag .ne. 0) then
+        call update_error(error,
+            "ddlpb: ddlpb_setup returned an error, exiting")
+        return
+    end if
     call ddlpb_guess(params, constants, workspace, state, tol, error)
+    if (error % flag .ne. 0) then
+        call update_error(error,
+            "ddlpb: ddlpb_guess returned an error, exiting")
+        return
+    end if
     call ddlpb_solve(params, constants, workspace, state, tol, error)
+    if (error % flag .ne. 0) then
+        call update_error(error,
+            "ddlpb: ddlpb_solve returned an error, exiting")
+        return
+    end if
 
     ! Compute the solvation energy
     call ddlpb_energy(constants, state, esolv, error)
@@ -62,7 +77,17 @@ subroutine ddlpb(params, constants, workspace, state, phi_cav, e_cav, &
     ! Get forces if needed
     if(params % force .eq. 1) then
         call ddlpb_guess_adjoint(params, constants, workspace, state, tol, error)
+        if (error % flag .ne. 0) then
+            call update_error(error,
+                "ddlpb: ddlpb_guess_adjoint returned an error, exiting")
+            return
+        end if
         call ddlpb_solve_adjoint(params, constants, workspace, state, tol, error)
+        if (error % flag .ne. 0) then
+            call update_error(error,
+                "ddlpb: ddlpb_solve_adjoint returned an error, exiting")
+            return
+        end if
         call ddlpb_solvation_force_terms(params, constants, workspace, &
             & state, hessianphi_cav, force, error)
     endif

--- a/src/ddx_operators.f90
+++ b/src/ddx_operators.f90
@@ -22,7 +22,7 @@ implicit none
 contains
 
 !> Single layer operator matvec
-subroutine lx(params, constants, workspace, x, y)
+subroutine lx(params, constants, workspace, x, y, error)
     implicit none
     !! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -32,6 +32,7 @@ subroutine lx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     !! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     !! Local variables
     integer :: isph, jsph, ij, l, ind, iproc
 
@@ -81,7 +82,7 @@ subroutine lx(params, constants, workspace, x, y)
 end subroutine lx
 
 !> Adjoint single layer operator matvec 
-subroutine lstarx(params, constants, workspace, x, y)
+subroutine lstarx(params, constants, workspace, x, y, error)
     implicit none
     !! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -91,6 +92,7 @@ subroutine lstarx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     !! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     !! Local variables
     integer :: isph, jsph, ij, indmat, igrid, l, ind, iproc
     y = zero
@@ -123,7 +125,6 @@ subroutine lstarx(params, constants, workspace, x, y)
             iproc = omp_get_thread_num() + 1
             call adjrhs(params, constants, isph, workspace % tmp_grid, &
                 & y(:, isph), workspace % tmp_work(:, iproc))
-    
             ! fix the sign
             y(:, isph) = - y(:, isph)
         end do
@@ -143,7 +144,7 @@ end subroutine lstarx
 !> Diagonal preconditioning for Lx operator
 !!
 !! Applies inverse diagonal (block) of the L matrix
-subroutine ldm1x(params, constants, workspace, x, y)
+subroutine ldm1x(params, constants, workspace, x, y, error)
     implicit none
     !! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -153,6 +154,7 @@ subroutine ldm1x(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     !! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     !! Local variables
     integer :: isph, l, ind
     ! workspace is here to comply with the interface
@@ -171,7 +173,7 @@ subroutine ldm1x(params, constants, workspace, x, y)
 end subroutine ldm1x
 
 !> Double layer operator matvec without diagonal blocks
-subroutine dx(params, constants, workspace, x, y)
+subroutine dx(params, constants, workspace, x, y, error)
     implicit none
     !! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -180,6 +182,7 @@ subroutine dx(params, constants, workspace, x, y)
     real(dp), intent(in) :: x(constants % nbasis, params % nsph)
     !! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     !! Local parameter
     integer :: do_diag
     !! initialize do_diag
@@ -187,14 +190,14 @@ subroutine dx(params, constants, workspace, x, y)
     if (constants % dodiag) do_diag = 1
     !! Select implementation
     if (params % fmm .eq. 0) then
-        call dx_dense(params, constants, workspace, do_diag, x, y)
+        call dx_dense(params, constants, workspace, do_diag, x, y, error)
     else
-        call dx_fmm(params, constants, workspace, do_diag, x, y)
+        call dx_fmm(params, constants, workspace, do_diag, x, y, error)
     end if
 end subroutine dx
 
 !> Baseline implementation of double layer operator
-subroutine dx_dense(params, constants, workspace, do_diag, x, y)
+subroutine dx_dense(params, constants, workspace, do_diag, x, y, error)
     implicit none
     !! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -202,6 +205,7 @@ subroutine dx_dense(params, constants, workspace, do_diag, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     integer, intent(in) :: do_diag
     real(dp), intent(in) :: x(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     !! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
     !! Local variables
@@ -271,7 +275,7 @@ subroutine dx_dense(params, constants, workspace, do_diag, x, y)
 end subroutine dx_dense
 
 !> FMM-accelerated implementation of double layer operator
-subroutine dx_fmm(params, constants, workspace, do_diag, x, y)
+subroutine dx_fmm(params, constants, workspace, do_diag, x, y, error)
     implicit none
     !! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -279,6 +283,7 @@ subroutine dx_fmm(params, constants, workspace, do_diag, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     integer, intent(in) :: do_diag
     real(dp), intent(in) :: x(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     !! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
     !! Local variables
@@ -332,7 +337,7 @@ subroutine dx_fmm(params, constants, workspace, do_diag, x, y)
 end subroutine dx_fmm
 
 !> Adjoint double layer operator matvec 
-subroutine dstarx(params, constants, workspace, x, y)
+subroutine dstarx(params, constants, workspace, x, y, error)
     implicit none
     !! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -342,6 +347,7 @@ subroutine dstarx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     !! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     !! Local variables
     integer :: do_diag
     !! initialize do_diag
@@ -349,14 +355,14 @@ subroutine dstarx(params, constants, workspace, x, y)
     if (constants % dodiag) do_diag = 1
     !! Select implementation
     if (params % fmm .eq. 0) then
-        call dstarx_dense(params, constants, workspace, do_diag, x, y)
+        call dstarx_dense(params, constants, workspace, do_diag, x, y, error)
     else
-        call dstarx_fmm(params, constants, workspace, do_diag, x, y)
+        call dstarx_fmm(params, constants, workspace, do_diag, x, y, error)
     end if
 end subroutine dstarx
 
 !> Baseline implementation of adjoint double layer operator
-subroutine dstarx_dense(params, constants, workspace, do_diag, x, y)
+subroutine dstarx_dense(params, constants, workspace, do_diag, x, y, error)
     implicit none
     ! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -365,6 +371,7 @@ subroutine dstarx_dense(params, constants, workspace, do_diag, x, y)
     real(dp), intent(in) :: x(constants % nbasis, params % nsph)
     ! Temporaries
     type(ddx_workspace_type), intent(inout) :: workspace
+    type(ddx_error_type), intent(inout) :: error
     ! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
     ! Local variables
@@ -428,7 +435,7 @@ subroutine dstarx_dense(params, constants, workspace, do_diag, x, y)
 end subroutine dstarx_dense
 
 !> FMM-accelerated implementation of adjoint double layer operator
-subroutine dstarx_fmm(params, constants, workspace, do_diag, x, y)
+subroutine dstarx_fmm(params, constants, workspace, do_diag, x, y, error)
     implicit none
     ! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -437,6 +444,7 @@ subroutine dstarx_fmm(params, constants, workspace, do_diag, x, y)
     real(dp), intent(in) :: x(constants % nbasis, params % nsph)
     ! Temporaries
     type(ddx_workspace_type), intent(inout) :: workspace
+    type(ddx_error_type), intent(inout) :: error
     ! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
     ! Local variables
@@ -491,7 +499,7 @@ end subroutine dstarx_fmm
 !!
 !! Compute \f$ y = R_\varepsilon x = (2\pi(\varepsilon + 1) / (\varepsilon
 !! - 1) - D) x \f$.
-subroutine repsx(params, constants, workspace, x, y)
+subroutine repsx(params, constants, workspace, x, y, error)
     implicit none
     !! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -501,10 +509,11 @@ subroutine repsx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     !! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     !! Local variables
     real(dp) :: fac
     !! Output `y` is cleaned here
-    call dx(params, constants, workspace, x, y)
+    call dx(params, constants, workspace, x, y, error)
     y = - y
     if (constants % dodiag) then
     ! Apply diagonal
@@ -517,7 +526,8 @@ end subroutine repsx
 !!
 !! Compute \f$ y = R^*_\varepsilon x = (2\pi(\varepsilon + 1) / (\varepsilon
 !! - 1) - D) x \f$.
-subroutine repsstarx(params, constants, workspace, x, y)
+!!
+subroutine repsstarx(params, constants, workspace, x, y, error)
     implicit none
     ! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -527,10 +537,11 @@ subroutine repsstarx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     ! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     ! Local variables
     real(dp) :: fac
     ! Output `y` is cleaned here
-    call dstarx(params, constants, workspace, x, y)
+    call dstarx(params, constants, workspace, x, y, error)
     y = - y
     ! Apply diagonal
     if (constants % dodiag) then 
@@ -546,7 +557,9 @@ end subroutine repsstarx
 !! @param[in] ddx_data:
 !! @param[in] x:
 !! @param[out] y:
-subroutine rinfx(params, constants, workspace, x, y)
+!! @param[inout] error: ddX error
+!!
+subroutine rinfx(params, constants, workspace, x, y, error)
     implicit none
     ! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -556,12 +569,13 @@ subroutine rinfx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     ! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     !! note do_diag hardcoded to 1.
     !! Select implementation
     if (params % fmm .eq. 0) then
-        call dx_dense(params, constants, workspace, 1, x, y)
+        call dx_dense(params, constants, workspace, 1, x, y, error)
     else
-        call dx_fmm(params, constants, workspace, 1, x, y)
+        call dx_fmm(params, constants, workspace, 1, x, y, error)
     end if
     ! Apply diagonal
     y = twopi*x - y
@@ -574,7 +588,9 @@ end subroutine rinfx
 !! @param[in] ddx_data:
 !! @param[in] x:
 !! @param[out] y:
-subroutine rstarinfx(params, constants, workspace, x, y)
+!! @param[inout] error: ddX error
+!!
+subroutine rstarinfx(params, constants, workspace, x, y, error)
     implicit none
     ! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -584,14 +600,16 @@ subroutine rstarinfx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     ! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     ! Output `y` is cleaned here
-    call dstarx(params, constants, workspace, x, y)
+    call dstarx(params, constants, workspace, x, y, error)
     ! Apply diagonal
     y = twopi*x - y
 end subroutine rstarinfx
 
 !> Apply preconditioner for ddPCM primal linear system
-subroutine prec_repsx(params, constants, workspace, x, y)
+!! @param[inout] error: ddX error
+subroutine prec_repsx(params, constants, workspace, x, y, error)
     implicit none
     ! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -601,10 +619,11 @@ subroutine prec_repsx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     ! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     integer :: isph
     ! workspace is here to comply with the interface
     ! this dummy statement disables the warnings
-    if (workspace % error_flag .eq. 0) continue
+    if ((workspace % error_flag .eq. 0) .or. (error % flag .eq. 0)) continue
     ! simply do a matrix-vector product with the transposed preconditioner 
     !$omp parallel do default(shared) schedule(static,1) &
     !$omp private(isph)
@@ -616,7 +635,7 @@ subroutine prec_repsx(params, constants, workspace, x, y)
 end subroutine prec_repsx
 
 !> Apply preconditioner for ddPCM adjoint linear system
-subroutine prec_repsstarx(params, constants, workspace, x, y)
+subroutine prec_repsstarx(params, constants, workspace, x, y, error)
     implicit none
     ! Inputs
     type(ddx_params_type), intent(in) :: params
@@ -626,11 +645,12 @@ subroutine prec_repsstarx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     ! Output
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     ! Local variables
     integer :: isph
-    ! workspace is here to comply with the interface
+    ! workspace and error are here to comply with the interface
     ! this dummy statement disables the warnings
-    if (workspace % error_flag .eq. 0) continue
+    if (workspace % error_flag .eq. 0 .and. error % flag .eq. 0) continue
     ! simply do a matrix-vector product with the transposed preconditioner 
     !$omp parallel do default(shared) schedule(static,1) &
     !$omp private(isph)
@@ -641,595 +661,15 @@ subroutine prec_repsstarx(params, constants, workspace, x, y)
     end do
 end subroutine prec_repsstarx
 
-!> Gradient of the ddPCM matrix
-subroutine gradr(params, constants, workspace, g, ygrid, fx)
-    implicit none
-    ! Inputs
-    type(ddx_params_type), intent(in) :: params
-    type(ddx_constants_type), intent(in) :: constants
-    real(dp), intent(in) :: g(constants % nbasis, params % nsph), &
-        & ygrid(params % ngrid, params % nsph)
-    ! Temporaries
-    type(ddx_workspace_type), intent(inout) :: workspace
-    ! Output
-    real(dp), intent(out) :: fx(3, params % nsph)
-    ! Check which gradr to execute
-    if (params % fmm .eq. 1) then
-        call gradr_fmm(params, constants, workspace, g, ygrid, fx)
-    else
-        call gradr_dense(params, constants, workspace, g, ygrid, fx)
-    end if
-end subroutine gradr
-
-!> Gradient of the ddPCM matrix using N^2 code
-subroutine gradr_dense(params, constants, workspace, g, ygrid, fx)
-    implicit none
-    ! Inputs
-    type(ddx_params_type), intent(in) :: params
-    type(ddx_constants_type), intent(in) :: constants
-    real(dp), intent(in) :: g(constants % nbasis, params % nsph), &
-        & ygrid(params % ngrid, params % nsph)
-    ! Temporaries
-    type(ddx_workspace_type), intent(inout) :: workspace
-    ! Output
-    real(dp), intent(out) :: fx(3, params % nsph)
-    ! Local variables
-    integer :: isph
-    ! Simply cycle over all spheres
-    do isph = 1, params % nsph
-        call gradr_sph(params, constants, isph, workspace % tmp_vplm, &
-            & workspace % tmp_vcos, workspace % tmp_vsin, &
-            & workspace % tmp_vylm, workspace % tmp_vdylm, &
-            & g, ygrid, fx(:, isph))
-    end do
-end subroutine gradr_dense
-
-!> Sphere contribution to the ddPCM matrix gradient using N^2 code
-subroutine gradr_sph(params, constants, isph, vplm, vcos, vsin, basloc, &
-        & dbsloc, g, ygrid, fx)
-    implicit none
-    ! Inputs
-    type(ddx_params_type), intent(in) :: params
-    type(ddx_constants_type), intent(in) :: constants
-    integer, intent(in) :: isph
-    real(dp), intent(in) :: g(constants % nbasis, params % nsph), &
-        & ygrid(params % ngrid, params % nsph)
-    real(dp), intent(inout) :: vplm(constants % nbasis), vcos(params % lmax+1), &
-        & vsin(params % lmax+1), basloc(constants % nbasis), &
-        & dbsloc(3, constants % nbasis), fx(3)
-    ! various scratch arrays
-    real(dp) vik(3), sik(3), vki(3), ski(3), vkj(3), skj(3), vji(3), &
-        & sji(3), va(3), vb(3), a(3)
-    ! jacobian matrix
-    real(dp) sjac(3,3)
-    ! indexes
-    integer its, ik, ksph, l, m, ind, jsph, icomp, jcomp
-    ! various scalar quantities
-    real(dp) cx, cy, cz, vvki, tki, gg, fl, fac, vvkj, tkj
-    real(dp) tt, fcl, fjj, gi, fii, vvji, tji, qji
-    real(dp) b, vvik, tik, qik, tlow, thigh, duj
-    real(dp) :: rho, ctheta, stheta, cphi, sphi
-    real(dp), external :: dnrm2
-
-    tlow  = one - pt5*(one - params % se)*params % eta
-    thigh = one + pt5*(one + params % se)*params % eta
-
-    ! first set of contributions:
-    ! diagonal block, kc and part of kb
-
-    fx = zero
-    do its = 1, params % ngrid
-        ! sum over ksph in neighbors of isph
-        do ik = constants % inl(isph), constants % inl(isph+1) - 1
-            ksph = constants % nl(ik)
-            ! build geometrical quantities
-            cx = params % csph(1,ksph) + params % rsph(ksph)*constants % cgrid(1,its)
-            cy = params % csph(2,ksph) + params % rsph(ksph)*constants % cgrid(2,its)
-            cz = params % csph(3,ksph) + params % rsph(ksph)*constants % cgrid(3,its)
-            vki(1) = cx - params % csph(1,isph)
-            vki(2) = cy - params % csph(2,isph)
-            vki(3) = cz - params % csph(3,isph)
-            !vvki = sqrt(vki(1)*vki(1) + vki(2)*vki(2) + &
-            !    & vki(3)*vki(3))
-            vvki = dnrm2(3, vki, 1)
-            tki  = vvki/params % rsph(isph)
-
-            ! contributions involving grad i of uk come from the switching
-            ! region.
-            ! note: ui avoids contributions from points that are in the
-            ! switching between isph and ksph but are buried in a third
-            ! sphere.
-            if ((tki.gt.tlow).and.(tki.lt.thigh) .and. &
-                & constants % ui(its,ksph).gt.zero) then
-                ! other geometrical quantities
-                ski = vki/vvki
-
-                ! diagonal block kk contribution, with k in n(i)
-                gg = zero
-                do l = 0, params % lmax
-                    ind = l*l + l + 1
-                    fl = dble(l)
-                    fac = twopi/(two*fl + one)
-                    do m = -l, l
-                        !! DEBUG comment
-                        gg = gg + fac*constants % vgrid(ind+m,its)*g(ind+m,ksph)
-                    end do
-                end do
-
-                ! kc contribution
-                do jsph = 1, params % nsph
-                    if (jsph.ne.ksph .and. jsph.ne.isph) then 
-                        vkj(1) = cx - params % csph(1,jsph)
-                        vkj(2) = cy - params % csph(2,jsph)
-                        vkj(3) = cz - params % csph(3,jsph)
-                        vvkj = sqrt(vkj(1)*vkj(1) + vkj(2)*vkj(2) + &
-                            & vkj(3)*vkj(3))
-                        vvkj = dnrm2(3, vkj, 1)
-                        tkj  = vvkj/params % rsph(jsph)
-                        skj  = vkj/vvkj
-                        call ylmbas(skj, rho, ctheta, stheta, cphi, sphi, &
-                            & params % lmax, constants % vscales, basloc, &
-                            & vplm, vcos, vsin)
-                        tt = one/tkj
-                        do l = 0, params % lmax
-                            ind = l*l + l + 1
-                            fcl = - fourpi*dble(l)/(two*dble(l)+one)*tt
-                            do m = -l, l
-                                !! DEBUG comment
-                                gg = gg + fcl*g(ind+m,jsph)*basloc(ind+m)
-                            end do
-                            tt = tt/tkj
-                        end do
-                        !call fmm_m2p(vkj, params % rsph(jsph), &
-                        !    & params % lmax, constants % vscales_rel, -one, &
-                        !    & g(:, jsph), one, gg)
-                    end if
-                end do
-
-                ! part of kb contribution
-                call ylmbas(ski, rho, ctheta, stheta, cphi, sphi, &
-                    & params % lmax, constants % vscales, basloc, &
-                    & vplm, vcos, vsin)
-                tt = one/tki
-                do l = 0, params % lmax
-                    ind = l*l + l + 1
-                    fcl = - four*pi*dble(l)/(two*dble(l)+one)*tt
-                    do m = -l, l
-                        !! DEBUG comment
-                        gg = gg + fcl*g(ind+m,isph)*basloc(ind+m)
-                    end do
-                    tt = tt/tki
-                end do
-                !call fmm_m2p(vki, params % rsph(isph), &
-                !    & params % lmax, constants % vscales_rel, -one, &
-                !    & g(:, isph), one, gg)
-
-                ! common step, product with grad i uj
-                duj = dfsw(tki,params % se, params % eta)/params % rsph(isph)
-                fjj = duj*constants % wgrid(its)*gg*ygrid(its,ksph)
-                fx(1) = fx(1) - fjj*ski(1)
-                fx(2) = fx(2) - fjj*ski(2)
-                fx(3) = fx(3) - fjj*ski(3)
-            end if
-        end do
-
-        ! diagonal block ii contribution
-        if (constants % ui(its,isph).gt.zero.and.constants % ui(its,isph).lt.one) then
-            gi = zero
-            do l = 0, params % lmax
-                ind = l*l + l + 1
-                fl = dble(l)
-                fac = twopi/(two*fl + one)
-                do m = -l, l 
-                    !! DEBUG comment
-                    gi = gi + fac*constants % vgrid(ind+m,its)*g(ind+m,isph)
-                    !gi = gi + pt5*constants % vgrid2(ind+m,its)*g(ind+m,isph)
-                end do
-            end do
-            !do l = 0, (params % lmax+1)**2
-            !    gi = gi + constants % vgrid2(l, its)*g(l, isph)
-            !end do
-            !gi = pt5 * gi
-            fii = constants % wgrid(its)*gi*ygrid(its,isph)
-            fx(1) = fx(1) + fii*constants % zi(1,its,isph)
-            fx(2) = fx(2) + fii*constants % zi(2,its,isph)
-            fx(3) = fx(3) + fii*constants % zi(3,its,isph)
-        end if
-    end do
-
-    ! second set of contributions:
-    ! part of kb and ka
-    do its = 1, params % ngrid
-
-        ! run over all the spheres except isph 
-        do jsph = 1, params % nsph
-            if (constants % ui(its,jsph).gt.zero .and. jsph.ne.isph) then
-                ! build geometrical quantities
-                cx = params % csph(1,jsph) + params % rsph(jsph)*constants % cgrid(1,its)
-                cy = params % csph(2,jsph) + params % rsph(jsph)*constants % cgrid(2,its)
-                cz = params % csph(3,jsph) + params % rsph(jsph)*constants % cgrid(3,its)
-                vji(1) = cx - params % csph(1,isph)
-                vji(2) = cy - params % csph(2,isph)
-                vji(3) = cz - params % csph(3,isph)
-                !vvji = sqrt(vji(1)*vji(1) + vji(2)*vji(2) + &
-                !    &  vji(3)*vji(3))
-                vvji = dnrm2(3, vji, 1)
-                tji = vvji/params % rsph(isph)
-                qji = one/vvji
-                sji = vji/vvji
-
-                ! build the jacobian of sji
-                sjac = zero
-                sjac(1,1) = - one
-                sjac(2,2) = - one
-                sjac(3,3) = - one
-                do icomp = 1, 3
-                    do jcomp = 1, 3
-                        sjac(icomp,jcomp) = qji*(sjac(icomp,jcomp) &
-                            & + sji(icomp)*sji(jcomp))
-                    end do
-                end do
-
-                ! assemble the local basis and its gradient
-                !call dbasis(sji,basloc,dbsloc,vplm,vcos,vsin)
-                call dbasis(params, constants, sji,basloc,dbsloc,vplm,vcos,vsin)
-
-                ! assemble the contribution
-                a = zero
-                tt = one/(tji)
-                do l = 0, params % lmax
-                    ind = l*l + l + 1
-                    fl = dble(l)
-                    fcl = - tt*fourpi*fl/(two*fl + one)
-                    do m = -l, l
-                        fac = fcl*g(ind+m,isph)
-                        b = (fl + one)*basloc(ind+m)/(params % rsph(isph)*tji)
-
-                        ! apply the jacobian to grad y
-                        va(1) = sjac(1,1)*dbsloc(1,ind+m) + &
-                            & sjac(1,2)*dbsloc(2,ind+m) + sjac(1,3)*dbsloc(3,ind+m)
-                        va(2) = sjac(2,1)*dbsloc(1,ind+m) + &
-                            & sjac(2,2)*dbsloc(2,ind+m) + sjac(2,3)*dbsloc(3,ind+m)
-                        va(3) = sjac(3,1)*dbsloc(1,ind+m) + &
-                            & sjac(3,2)*dbsloc(2,ind+m) + sjac(3,3)*dbsloc(3,ind+m)
-                        a(1) = a(1) + fac*(sji(1)*b + va(1))
-                        a(2) = a(2) + fac*(sji(2)*b + va(2))
-                        a(3) = a(3) + fac*(sji(3)*b + va(3))
-                    end do
-                    tt = tt/tji
-                end do
-                fac = constants % ui(its,jsph)*constants % wgrid(its)*ygrid(its,jsph)
-                fx(1) = fx(1) - fac*a(1)
-                fx(2) = fx(2) - fac*a(2)
-                fx(3) = fx(3) - fac*a(3)
-            end if
-        end do
-    end do
-
-    ! ka contribution
-    do its = 1, params % ngrid
-        cx = params % csph(1,isph) + params % rsph(isph)*constants % cgrid(1,its)
-        cy = params % csph(2,isph) + params % rsph(isph)*constants % cgrid(2,its)
-        cz = params % csph(3,isph) + params % rsph(isph)*constants % cgrid(3,its)
-        a = zero
-
-        ! iterate on all the spheres except isph
-        do ksph = 1, params % nsph
-            if (constants % ui(its,isph).gt.zero .and. ksph.ne.isph) then
-                ! geometrical stuff
-                vik(1) = cx - params % csph(1,ksph)
-                vik(2) = cy - params % csph(2,ksph)
-                vik(3) = cz - params % csph(3,ksph)
-                !vvik = sqrt(vik(1)*vik(1) + vik(2)*vik(2) + & 
-                !    & vik(3)*vik(3))
-                vvik = dnrm2(3, vik, 1)
-                tik = vvik/params % rsph(ksph)
-                qik = one/vvik
-                sik = vik/vvik
-
-                ! build the jacobian of sik
-                sjac = zero
-                sjac(1,1) = one
-                sjac(2,2) = one
-                sjac(3,3) = one
-                do icomp = 1, 3
-                    do jcomp = 1, 3
-                    sjac(icomp,jcomp) = qik*(sjac(icomp,jcomp) &
-                        & - sik(icomp)*sik(jcomp))
-                    end do
-                end do
-
-                ! if we are in the switching region, recover grad_i u_i
-                vb = zero
-                if (constants % ui(its,isph).lt.one) then
-                    vb(1) = constants % zi(1,its,isph)
-                    vb(2) = constants % zi(2,its,isph)
-                    vb(3) = constants % zi(3,its,isph)
-                end if
-
-                ! assemble the local basis and its gradient
-                !call dbasis(sik,basloc,dbsloc,vplm,vcos,vsin)
-                call dbasis(params, constants, sik,basloc,dbsloc,vplm,vcos,vsin)
-
-                ! assemble the contribution
-                tt = one/(tik)
-                do l = 0, params % lmax
-                    ind = l*l + l + 1
-                    fl = dble(l)
-                    fcl = - tt*fourpi*fl/(two*fl + one)
-                        do m = -l, l
-                        fac = fcl*g(ind+m,ksph)
-                        fac = - fac*basloc(ind+m)
-                        a(1) = a(1) + fac*vb(1)
-                        a(2) = a(2) + fac*vb(2) 
-                        a(3) = a(3) + fac*vb(3)
-
-                        fac = constants % ui(its,isph)*fcl*g(ind+m,ksph)
-                        b = - (fl + one)*basloc(ind+m)/(params % rsph(ksph)*tik)
-
-                        ! apply the jacobian to grad y
-                        va(1) = sjac(1,1)*dbsloc(1,ind+m) + &
-                            & sjac(1,2)*dbsloc(2,ind+m) + sjac(1,3)*dbsloc(3,ind+m)
-                        va(2) = sjac(2,1)*dbsloc(1,ind+m) + &
-                            & sjac(2,2)*dbsloc(2,ind+m) + sjac(2,3)*dbsloc(3,ind+m)
-                        va(3) = sjac(3,1)*dbsloc(1,ind+m) + &
-                            & sjac(3,2)*dbsloc(2,ind+m) + sjac(3,3)*dbsloc(3,ind+m)
-                        a(1) = a(1) + fac*(sik(1)*b + va(1))
-                        a(2) = a(2) + fac*(sik(2)*b + va(2))
-                        a(3) = a(3) + fac*(sik(3)*b + va(3))
-                    end do
-                    tt = tt/tik
-                end do
-            end if
-        end do
-        fac = constants % wgrid(its)*ygrid(its,isph)
-        fx(1) = fx(1) - fac*a(1)
-        fx(2) = fx(2) - fac*a(2)
-        fx(3) = fx(3) - fac*a(3)
-    end do
-end subroutine gradr_sph
-
-!> Compute the ddPCM matrix gradient using FMMS (2 matvecs)
-subroutine gradr_fmm(params, constants, workspace, g, ygrid, fx)
-    implicit none
-    ! Inputs
-    type(ddx_params_type), intent(in) :: params
-    type(ddx_constants_type), intent(in) :: constants
-    real(dp), intent(in) :: g(constants % nbasis, params % nsph), &
-        & ygrid(params % ngrid, params % nsph)
-    ! Temporaries
-    type(ddx_workspace_type), intent(inout) :: workspace
-    ! Output
-    real(dp), intent(out) :: fx(3, params % nsph)
-    ! Local variables
-    integer :: indl, indl1, l, isph, igrid, ik, ksph, &
-        & jsph, jsph_node
-    integer :: inear, inode, jnode
-    real(dp) :: gg, c(3), vki(3), vvki, tki, gg3(3), tmp_gg, tmp_c(3)
-    real(dp) :: tlow, thigh
-    real(dp), dimension(3, 3) :: zx_coord_transform, zy_coord_transform
-    real(dp), external :: ddot, dnrm2
-    real(dp) :: work(params % lmax+2)
-    !real(dp) :: l2g(params % ngrid, params % nsph)
-    zx_coord_transform = 0
-    zx_coord_transform(3, 2) = 1
-    zx_coord_transform(2, 3) = 1
-    zx_coord_transform(1, 1) = 1
-    zy_coord_transform = 0
-    zy_coord_transform(1, 2) = 1
-    zy_coord_transform(2, 1) = 1
-    zy_coord_transform(3, 3) = 1
-    tlow  = one - pt5*(one - params % se)*params % eta
-    thigh = one + pt5*(one + params % se)*params % eta
-    fx = zero
-    !! Scale input harmonics at first
-    workspace % tmp_sph(1, :) = zero
-    indl = 2
-    do l = 1, params % lmax
-        indl1 = (l+1)**2
-        workspace % tmp_sph(indl:indl1, :) = l * g(indl:indl1, :)
-        indl = indl1 + 1
-    end do
-    !! Compute gradient of M2M of tmp_sph harmonics at the origin and store it
-    !! in tmp_sph_grad. tmp_sph_grad(:, 1, :), tmp_sph_grad(:, 2, :) and
-    !! tmp_sph_grad(:, 3, :) correspond to the OX, OY and OZ axes. Variable
-    !! tmp_sph2 is a temporary workspace here.
-    call tree_grad_m2m(params, constants, workspace % tmp_sph, &
-        & workspace % tmp_sph_grad, workspace % tmp_sph2)
-    !! Adjoint full FMM matvec to get output multipole expansions from input
-    !! external grid points. It is used to compute R_i^B fast as a contraction
-    !! of a gradient stored in tmp_sph_grad and a result of adjoint matvec.
-    ! Adjoint integration from spherical harmonics to grid points is not needed
-    ! here as ygrid already contains grid values, we just need to scale it by
-    ! weights of grid points
-    do isph = 1, params % nsph
-        workspace % tmp_grid(:, isph) = ygrid(:, isph) * &
-            & constants % wgrid(:) * constants % ui(:, isph)
-    end do
-    ! Adjoint FMM with output tmp_sph2(:, :) which stores coefficients of
-    ! harmonics of degree up to lmax+1
-    call tree_m2p_adj(params, constants, params % lmax+1, one, &
-        & workspace % tmp_grid, zero, workspace % tmp_sph2)
-    call tree_l2p_adj(params, constants, one, workspace % tmp_grid, zero, &
-        & workspace % tmp_node_l, workspace % tmp_sph_l)
-    call tree_l2l_rotation_adj(params, constants, workspace % tmp_node_l)
-    call tree_m2l_rotation_adj(params, constants, workspace % tmp_node_l, &
-        & workspace % tmp_node_m)
-    call tree_m2m_rotation_adj(params, constants, workspace % tmp_node_m)
-    ! Properly load adjoint multipole harmonics into tmp_sph2 that holds
-    ! harmonics of a degree up to lmax+1
-    if(params % lmax+1 .lt. params % pm) then
-        do isph = 1, params % nsph
-            inode = constants % snode(isph)
-            workspace % tmp_sph2(:, isph) = workspace % tmp_sph2(:, isph) + &
-                & workspace % tmp_node_m(1:constants % grad_nbasis, inode)
-        end do
-    else
-        indl = (params % pm+1)**2
-        do isph = 1, params % nsph
-            inode = constants % snode(isph)
-            workspace % tmp_sph2(1:indl, isph) = &
-                & workspace % tmp_sph2(1:indl, isph) + &
-                & workspace % tmp_node_m(:, inode)
-        end do
-    end if
-    ! Compute second term of R_i^B as a contraction
-    do isph = 1, params % nsph
-        call dgemv('T', constants % grad_nbasis, 3, one, &
-            & workspace % tmp_sph_grad(1, 1, isph), constants % grad_nbasis, &
-            & workspace % tmp_sph2(1, isph), 1, zero, fx(1, isph), 1)
-    end do
-    !! Direct far-field FMM matvec to get output local expansions from input
-    !! multipole expansions. It will be used in R_i^A.
-    !! As of now I compute potential at all external grid points, improved
-    !! version shall only compute it at external points in a switch region
-    ! Load input harmonics into tree data
-    if(params % lmax .lt. params % pm) then
-        do isph = 1, params % nsph
-            inode = constants % snode(isph)
-            workspace % tmp_node_m(:constants % nbasis, inode) = &
-                & workspace % tmp_sph(:, isph)
-            workspace % tmp_node_m(constants % nbasis+1:, inode) = zero
-        end do
-    else
-        indl = (params % pm+1)**2
-        do isph = 1, params % nsph
-            inode = constants % snode(isph)
-            workspace % tmp_node_m(:, inode) = workspace % tmp_sph(1:indl, isph)
-        end do
-    end if
-    ! Perform direct FMM matvec to all external grid points
-    call tree_m2m_rotation(params, constants, workspace % tmp_node_m)
-    call tree_m2l_rotation(params, constants, workspace % tmp_node_m, &
-        & workspace % tmp_node_l)
-    call tree_l2l_rotation(params, constants, workspace % tmp_node_l)
-    call tree_l2p(params, constants, one, workspace % tmp_node_l, zero, &
-        & workspace % tmp_grid, workspace % tmp_sph_l)
-    call tree_m2p(params, constants, params % lmax, one, &
-        & workspace % tmp_sph, one, workspace % tmp_grid)
-    !! Compute gradients of L2L if pl > 0
-    if (params % pl .gt. 0) then
-        call tree_grad_l2l(params, constants, workspace % tmp_node_l, &
-            & workspace % tmp_sph_l_grad, workspace % tmp_sph_l)
-    end if
-    !! Diagonal update of computed grid values, that is needed for R^C, a part
-    !! of R^A and a part of R^B
-    call dgemm('T', 'N', params % ngrid, params % nsph, constants % nbasis, &
-        & pt5, constants % vgrid2, constants % vgrid_nbasis, g, &
-        & constants % nbasis, -one, workspace % tmp_grid, params % ngrid)
-    !! Scale temporary grid points by corresponding Lebedev weights and ygrid
-    do igrid = 1, params % ngrid
-        do isph = 1, params % nsph
-            workspace % tmp_grid(igrid, isph) = &
-                & workspace % tmp_grid(igrid, isph) *  constants % wgrid(igrid) * &
-                & ygrid(igrid, isph)
-        end do
-    end do
-    !! Compute all terms of grad_i(R). The second term of R_i^B is already
-    !! taken into account and the first term is computed together with R_i^C.
-    do isph = 1, params % nsph
-        do igrid = 1, params % ngrid
-            ! Loop over all neighbouring spheres
-            do ik = constants % inl(isph), constants % inl(isph+1) - 1
-                ksph = constants % nl(ik)
-                ! Only consider external grid points
-                if(constants % ui(igrid, ksph) .eq. zero) cycle
-                ! build geometrical quantities
-                c = params % csph(:, ksph) + &
-                    & params % rsph(ksph)*constants % cgrid(:, igrid)
-                vki = c - params % csph(:, isph)
-                !vvki = sqrt(vki(1)*vki(1) + vki(2)*vki(2) + &
-                !    & vki(3)*vki(3))
-                vvki = dnrm2(3, vki, 1)
-                tki = vvki / params % rsph(isph)
-                ! Only consider such points where grad U is non-zero
-                if((tki.le.tlow) .or. (tki.ge.thigh)) cycle
-                ! This is entire R^C and the first R^B component (grad_i of U
-                ! of a sum of R_kj for index inequality j!=k)
-                ! Indexes k and j are flipped compared to the paper
-                gg = workspace % tmp_grid(igrid, ksph)
-                ! Compute grad_i component of forces using precomputed
-                ! potential gg
-                !fx(:, isph) = fx(:, isph) - &
-                !    & dfsw(tki, params % se, params % eta)/ &
-                !    & params % rsph(isph)*constants % wgrid(igrid)*gg* &
-                !    & ygrid(igrid, ksph)*(vki/vvki)
-                fx(:, isph) = fx(:, isph) - &
-                    & dfsw(tki, params % se, params % eta)/ &
-                    & params % rsph(isph)*gg*(vki/vvki)
-            end do
-            ! contribution from the sphere itself
-            if((constants % ui(igrid,isph).gt.zero) .and. &
-                & (constants % ui(igrid,isph).lt.one)) then
-                ! R^A component (grad_i of U of a sum of R_ij for index
-                ! inequality j!=i)
-                ! Indexes k and j are flipped compared to the paper
-                gg = workspace % tmp_grid(igrid, isph)
-                ! Compute grad_i component of forces using precomputed
-                ! potential gg
-                !fx(:, isph) = fx(:, isph) + constants % wgrid(igrid)*gg* &
-                !    & ygrid(igrid, isph)*constants % zi(:, igrid, isph)
-                fx(:, isph) = fx(:, isph) + gg*constants % zi(:, igrid, isph)
-            end if
-            if (constants % ui(igrid, isph) .gt. zero) then
-                ! Another R^A component (grad_i of potential of a sum of R_ij
-                ! for index inequality j!=i)
-                ! Indexes k and j are flipped compared to the paper
-                ! In case pl=0 MKL does not make gg3 zero reusing old value of
-                ! gg3, so we have to clear it manually
-                gg3 = zero
-                call dgemv('T', params % pl**2, 3, one, &
-                    & workspace % tmp_sph_l_grad(1, 1, isph), &
-                    & (params % pl+1)**2, constants % vgrid2(1, igrid), 1, &
-                    & zero, gg3, 1)
-                ! Gradient of the near-field potential is a gradient of
-                ! multipole expansion
-                inode = constants % snode(isph)
-                do inear = constants % snear(inode), constants % snear(inode+1)-1
-                    jnode = constants % near(inear)
-                    do jsph_node = constants % cluster(1, jnode), &
-                        & constants % cluster(2, jnode)
-                        jsph = constants % order(jsph_node)
-                        if (isph .eq. jsph) cycle
-                        c = params % csph(:, isph) + &
-                            & params % rsph(isph)*constants % cgrid(:, igrid)
-                        tmp_c = c - params % csph(:, jsph)
-                        call fmm_m2p_work(tmp_c, &
-                            & params % rsph(jsph), params % lmax+1, &
-                            & constants % vscales_rel, one, &
-                            & workspace % tmp_sph_grad(:, 1, jsph), zero, &
-                            & tmp_gg, work)
-                        gg3(1) = gg3(1) + tmp_gg
-                        call fmm_m2p_work(tmp_c, &
-                            & params % rsph(jsph), params % lmax+1, &
-                            & constants % vscales_rel, one, &
-                            & workspace % tmp_sph_grad(:, 2, jsph), zero, &
-                            & tmp_gg, work)
-                        gg3(2) = gg3(2) + tmp_gg
-                        call fmm_m2p_work(tmp_c, &
-                            & params % rsph(jsph), params % lmax+1, &
-                            & constants % vscales_rel, one, &
-                            & workspace % tmp_sph_grad(:, 3, jsph), zero, &
-                            & tmp_gg, work)
-                        gg3(3) = gg3(3) + tmp_gg
-                    end do
-                end do
-                ! Accumulate all computed forces
-                fx(:, isph) = fx(:, isph) - constants % wgrid(igrid)*gg3* &
-                    & ygrid(igrid, isph)*constants % ui(igrid, isph)
-            end if
-        end do
-    end do
-end subroutine gradr_fmm
-
 !> Adjoint HSP matrix vector product
-subroutine bstarx(params, constants, workspace, x, y)
+subroutine bstarx(params, constants, workspace, x, y, error)
     ! Inputs
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_workspace_type), intent(inout) :: workspace
     real(dp), intent(in) :: x(constants % nbasis, params % nsph)
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+    type(ddx_error_type), intent(inout) :: error
     ! Local variables
     integer :: isph, jsph, ij, indmat, iproc
     y = zero
@@ -1270,13 +710,14 @@ subroutine bstarx(params, constants, workspace, x, y)
 end subroutine bstarx
 
 !> Primal HSP matrix vector product
-subroutine bx(params, constants, workspace, x, y)
+subroutine bx(params, constants, workspace, x, y, error)
     implicit none
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_workspace_type), intent(inout) :: workspace
     real(dp), dimension(constants % nbasis, params % nsph), intent(in) :: x
     real(dp), dimension(constants % nbasis, params % nsph), intent(out) :: y
+    type(ddx_error_type), intent(inout) :: error
     integer :: isph, jsph, ij, iproc
 
     y = zero
@@ -1306,13 +747,14 @@ subroutine bx(params, constants, workspace, x, y)
 end subroutine bx
 
 !> Adjoint ddLPB matrix-vector product
-subroutine tstarx(params, constants, workspace, x, y)
+subroutine tstarx(params, constants, workspace, x, y, error)
     implicit none
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_workspace_type), intent(inout) :: workspace
     real(dp), dimension(constants % nbasis, params % nsph, 2), intent(in) :: x
     real(dp), dimension(constants % nbasis, params % nsph, 2), intent(out) :: y
+    type(ddx_error_type), intent(inout) :: error
 
     real(dp), dimension(constants % nbasis, params % nsph, 2) :: temp_vector
     y = zero
@@ -1320,44 +762,50 @@ subroutine tstarx(params, constants, workspace, x, y)
 
     ! Compute AXr
     ! call LstarXr
-    call lstarx(params, constants, workspace, x(:,:,1), temp_vector(:,:,1))
+    call lstarx(params, constants, workspace, x(:,:,1), temp_vector(:,:,1), &
+        & error)
     ! Remove the scaling factor
     call convert_ddcosmo(params, constants, 1, temp_vector(:,:,1))
     y(:,:,1) = y(:,:,1) + temp_vector(:,:,1)
     ! Compute BXe
-    call bstarx(params, constants, workspace, x(:,:,2), temp_vector(:,:,2))
+    call bstarx(params, constants, workspace, x(:,:,2), temp_vector(:,:,2), &
+        & error)
     y(:,:,2) = y(:,:,2) + temp_vector(:,:,2)
 
     ! Reset temp_vector to zero
     temp_vector = zero
     ! Call CX
-    call cstarx(params, constants, workspace, x, temp_vector)
+    call cstarx(params, constants, workspace, x, temp_vector, error)
     y = y + temp_vector
 end subroutine tstarx
 
 !> Apply the preconditioner to the primal HSP linear system
-subroutine bx_prec(params, constants, workspace, x, y)
+!! @param[inout] error: ddX error
+subroutine bx_prec(params, constants, workspace, x, y, error)
     implicit none
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_workspace_type), intent(inout) :: workspace
     real(dp), dimension(constants % nbasis, params % nsph), intent(in) :: x
     real(dp), dimension(constants % nbasis, params % nsph), intent(out) :: y
+    type(ddx_error_type), intent(inout) :: error
     ! params, costants and workspace are here to comply with the interface
     ! this dummy statement disables the warnings
     if ((params % error_flag .eq. 0) .or. (constants % error_flag .eq. 0) &
-        & .or. (workspace % error_flag .eq. 0)) continue
+        & .or. (workspace % error_flag .eq. 0) .or. (error % flag .eq. 0)) &
+        continue
     y = x
 end subroutine bx_prec
 
 !> Apply the preconditioner to the ddLPB adjoint linear system
-subroutine prec_tstarx(params, constants, workspace, x, y)
+subroutine prec_tstarx(params, constants, workspace, x, y, error)
     implicit none
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_workspace_type), intent(inout) :: workspace
     real(dp), intent(in) :: x(constants % nbasis, params % nsph, 2)
     real(dp), intent(inout) :: y(constants % nbasis, params % nsph, 2)
+    type(ddx_error_type), intent(inout) :: error
     integer :: n_iter
     real(dp), dimension(params % maxiter) :: x_rel_diff
     real(dp) :: start_time
@@ -1368,9 +816,10 @@ subroutine prec_tstarx(params, constants, workspace, x, y)
     n_iter = params % maxiter
     call jacobi_diis(params, constants, workspace, constants % inner_tol, &
         & y(:,:,1), workspace % ddcosmo_guess, n_iter, x_rel_diff, lstarx, &
-        & ldm1x, hnorm)
-    if (workspace % error_flag.ne.0) then
-        workspace % error_message = 'prec_tstarx: ddCOSMO failed to converge'
+        & ldm1x, hnorm, error)
+    if (error % flag .ne. 0) then
+        call update_error(error, 'prec_tstarx: ddCOSMO failed to ' // &
+            & 'converge, exiting')
         return
     end if
     y(:,:,1) = workspace % ddcosmo_guess
@@ -1380,9 +829,10 @@ subroutine prec_tstarx(params, constants, workspace, x, y)
     n_iter = params % maxiter
     call jacobi_diis(params, constants, workspace, constants % inner_tol, &
         & x(:,:,2), workspace % hsp_guess, n_iter, x_rel_diff, bstarx, &
-        & bx_prec, hnorm)
-    if (workspace % error_flag.ne.0) then
-        workspace % error_message = 'prec_tstarx: HSP failed to converge'
+        & bx_prec, hnorm, error)
+    if (error % flag .ne. 0) then
+        call update_error(error, 'prec_tstarx: HSP failed to ' // &
+            & 'converge, exiting')
         return
     end if
     y(:,:,2) = workspace % hsp_guess
@@ -1397,13 +847,15 @@ end subroutine prec_tstarx
 !! @param[in] ddx_data : dd Data
 !! @param[in] x        : Input array
 !! @param[out] y       : Linear system solution at current iteration
-subroutine prec_tx(params, constants, workspace, x, y)
+!! @param[inout] error: ddX error
+subroutine prec_tx(params, constants, workspace, x, y, error)
     implicit none
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_workspace_type), intent(inout) :: workspace
     real(dp), intent(in) :: x(constants % nbasis, params % nsph, 2)
     real(dp), intent(inout) :: y(constants % nbasis, params % nsph, 2)
+    type(ddx_error_type), intent(inout) :: error
     integer :: n_iter
     real(dp), dimension(params % maxiter) :: x_rel_diff
     real(dp) :: start_time
@@ -1413,9 +865,10 @@ subroutine prec_tx(params, constants, workspace, x, y)
     n_iter = params % maxiter
     call jacobi_diis(params, constants, workspace, constants % inner_tol, &
         & x(:,:,1), workspace % ddcosmo_guess, n_iter, x_rel_diff, lx, &
-        & ldm1x, hnorm)
-    if (workspace % error_flag.ne.0) then
-        workspace % error_message = 'prec_tx: ddCOSMO failed to converge'
+        & ldm1x, hnorm, error)
+    if (error % flag .ne. 0) then
+        call update_error(error, 'prec_tx: ddCOSMO failed to ' // &
+            & 'converge, exiting')
         return
     end if
 
@@ -1429,18 +882,20 @@ subroutine prec_tx(params, constants, workspace, x, y)
     n_iter = params % maxiter
     call jacobi_diis(params, constants, workspace, constants % inner_tol, &
         & x(:,:,2), workspace % hsp_guess, n_iter, x_rel_diff, bx, &
-        & bx_prec, hnorm)
+        & bx_prec, hnorm, error)
     y(:,:,2) = workspace % hsp_guess
     workspace % hsp_time = workspace % hsp_time + omp_get_wtime() - start_time
 
-    if (workspace % error_flag.ne.0) then
-        workspace % error_message = 'prec_tx: HSP failed to converge'
+    if (error % flag .ne. 0) then
+        call update_error(error, 'prec_tx: HSP failed to ' // &
+            & 'converge, exiting')
         return
     end if
+
 end subroutine prec_tx
 
 !> ddLPB adjoint matrix-vector product
-subroutine cstarx(params, constants, workspace, x, y)
+subroutine cstarx(params, constants, workspace, x, y, error)
     implicit none
     ! input/output
     type(ddx_params_type), intent(in) :: params
@@ -1448,6 +903,7 @@ subroutine cstarx(params, constants, workspace, x, y)
     type(ddx_workspace_type), intent(inout) :: workspace
     real(dp), dimension(constants % nbasis, params % nsph, 2), intent(in) :: x
     real(dp), dimension(constants % nbasis, params % nsph, 2), intent(out) :: y
+    type(ddx_error_type), intent(inout) :: error
     ! local
     complex(dp) :: work_complex(constants % lmax0+1)
     real(dp) :: work(constants % lmax0+1)
@@ -1551,13 +1007,14 @@ subroutine cstarx(params, constants, workspace, x, y)
 end subroutine cstarx
 
 !> ddLPB matrix-vector product
-subroutine cx(params, constants, workspace, x, y)
+subroutine cx(params, constants, workspace, x, y, error)
     implicit none
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
     type(ddx_workspace_type), intent(inout) :: workspace
     real(dp), dimension(constants % nbasis, params % nsph, 2), intent(in) :: x
     real(dp), dimension(constants % nbasis, params % nsph, 2), intent(out) :: y
+    type(ddx_error_type), intent(inout) :: error
 
     integer :: isph, jsph, igrid, ind, l, m, ind0
     real(dp), dimension(3) :: sijn ,vij, vtij
@@ -1690,4 +1147,3 @@ subroutine cx(params, constants, workspace, x, y)
 end subroutine cx
 
 end module ddx_operators
-

--- a/src/ddx_operators.f90
+++ b/src/ddx_operators.f90
@@ -157,9 +157,6 @@ subroutine ldm1x(params, constants, workspace, x, y, error)
     type(ddx_error_type), intent(inout) :: error
     !! Local variables
     integer :: isph, l, ind
-    ! workspace is here to comply with the interface
-    ! this dummy statement disables the warnings
-    if (workspace % error_flag .eq. 0) continue
     !! Loop over harmonics
     !$omp parallel do default(none) shared(params,constants,x,y) &
     !$omp private(isph,l,ind) schedule(dynamic)
@@ -621,9 +618,6 @@ subroutine prec_repsx(params, constants, workspace, x, y, error)
     real(dp), intent(out) :: y(constants % nbasis, params % nsph)
     type(ddx_error_type), intent(inout) :: error
     integer :: isph
-    ! workspace is here to comply with the interface
-    ! this dummy statement disables the warnings
-    if ((workspace % error_flag .eq. 0) .or. (error % flag .eq. 0)) continue
     ! simply do a matrix-vector product with the transposed preconditioner 
     !$omp parallel do default(shared) schedule(static,1) &
     !$omp private(isph)
@@ -648,9 +642,6 @@ subroutine prec_repsstarx(params, constants, workspace, x, y, error)
     type(ddx_error_type), intent(inout) :: error
     ! Local variables
     integer :: isph
-    ! workspace and error are here to comply with the interface
-    ! this dummy statement disables the warnings
-    if (workspace % error_flag .eq. 0 .and. error % flag .eq. 0) continue
     ! simply do a matrix-vector product with the transposed preconditioner 
     !$omp parallel do default(shared) schedule(static,1) &
     !$omp private(isph)
@@ -789,11 +780,6 @@ subroutine bx_prec(params, constants, workspace, x, y, error)
     real(dp), dimension(constants % nbasis, params % nsph), intent(in) :: x
     real(dp), dimension(constants % nbasis, params % nsph), intent(out) :: y
     type(ddx_error_type), intent(inout) :: error
-    ! params, costants and workspace are here to comply with the interface
-    ! this dummy statement disables the warnings
-    if ((params % error_flag .eq. 0) .or. (constants % error_flag .eq. 0) &
-        & .or. (workspace % error_flag .eq. 0) .or. (error % flag .eq. 0)) &
-        continue
     y = x
 end subroutine bx_prec
 

--- a/src/ddx_parameters.f90
+++ b/src/ddx_parameters.f90
@@ -123,10 +123,7 @@ contains
 !! @param[in] rsph: Van-der-Waals radii of atoms. Dimension is `(nsph)`.
 !! @param[in] output_filename: file name of log file.
 !! @param[out] params: Object containing all inputs.
-!!      = 0: Succesfull exit
-!!      = -1: One of the arguments had an illegal value, check
-!!          params % error_message
-!!      = 1: Allocation of memory to copy geometry data failed.
+!! @param[inout] error: ddX error
 subroutine params_init(model, force, eps, kappa, eta, se, lmax, ngrid, &
         & matvecmem, maxiter, jacobi_ndiis, fmm, pm, pl, nproc, nsph, &
         & csph, rsph, output_filename, params, error)
@@ -341,10 +338,8 @@ end subroutine params_init
 
 !> Free memory used by parameters
 !! @param[inout] params: Object containing all inputs
-!! @param[out] info: flag of succesfull exit
-!!      = 0: Succesfull exit
-!!      = -1: params is in error state
-!!      = 1: Deallocation of memory failed.
+!! @param[inout] error: ddX error
+!!
 subroutine params_deinit(params)
     !! Input
     type(ddx_params_type), intent(inout) :: params

--- a/src/ddx_parameters.f90
+++ b/src/ddx_parameters.f90
@@ -177,7 +177,6 @@ subroutine params_init(model, force, eps, kappa, eta, se, lmax, ngrid, &
     if (error % flag .ne. 0) then
         call update_error(error, "params_init received input in error " // &
             & " state, exiting")
-        return
     end if
     ! parse the log file name
     if (len(trim(output_filename)) .ne. 0) then
@@ -192,43 +191,36 @@ subroutine params_init(model, force, eps, kappa, eta, se, lmax, ngrid, &
     ! Model, 1=COSMO, 2=PCM, 3=LPB
     if ((model .lt. 1) .or. (model .gt. 3)) then
         call update_error(error, "params_init: invalid value of `model`")
-        return
     end if
     params % model = model
     ! Check if forces are needed
     if ((force .lt. 0) .or. (force .gt. 1)) then
         call update_error(error, "params_init: invalid value of `force`")
-        return
     end if
     params % force = force
     ! Relative dielectric permittivity
     if (eps .le. one) then
         call update_error(error, "params_init: invalid value of `eps`")
-        return
     end if
     params % eps = eps
     ! Debye-H\"{u}ckel parameter (only used in ddLPB)
     if ((model .eq. 3) .and. (kappa .le. zero)) then
         call update_error(error, "params_init: invalid value of `kappa`")
-        return
     end if
     params % kappa = kappa
     ! Regularization parameter
     if ((eta .lt. zero) .or. (eta .gt. one)) then
         call update_error(error, "params_init: invalid value of `eta`")
-        return
     end if
     params % eta = eta
     ! Shift of a regularization
     if ((se .lt. -one) .or. (se .gt. one)) then
         call update_error(error, "params_init: invalid value of `se`")
-        return
     end if
     params % se = se
     ! Degree of modeling spherical harmonics
     if (lmax .lt. 0) then
         call update_error(error, "params_init: invalid value of `lmax`")
-        return
     end if
     params % lmax = lmax
     ! Check number of Lebedev grid points
@@ -241,25 +233,21 @@ subroutine params_init(model, force, eps, kappa, eta, se, lmax, ngrid, &
     end do
     if (igrid .eq. 0) then
         call update_error(error, "params_init: Unsupported value of `ngrid`")
-        return
     end if
     params % ngrid = ngrid
     ! Maximum number of iterations
     if (maxiter .le. 0) then
         call update_error(error, "params_init: invalid value of `maxiter`")
-        return
     end if
     params % maxiter = maxiter
     ! Number of Jacobi DIIS extrapolation points (ndiis=25 works)
     if (jacobi_ndiis .lt. 0) then
         call update_error(error, "params_init: invalid value of `jacobi_ndiis`")
-        return
     end if
     params % jacobi_ndiis = jacobi_ndiis
     ! Check if FMM-acceleration is needed
     if ((fmm .lt. 0) .or. (fmm .gt. 1)) then
         call update_error(error, "params_init: invalid value of `fmm`")
-        return
     end if
     params % fmm = fmm
     ! Set FMM parameters if FMM is needed
@@ -269,14 +257,12 @@ subroutine params_init(model, force, eps, kappa, eta, se, lmax, ngrid, &
         ! interactions are taken into account.
         if (pm .lt. -1) then
             call update_error(error, "params_init: invalid value of `pm`")
-            return
         end if
         ! Maximal degree of local spherical harmonics. Value -1 means no 
         ! far-field interactions are to be computed, only near-field
         ! interactions are taken into account.
         if (pl .lt. -1) then
             call update_error(error, "params_init: invalid value of `pl`")
-            return
         end if
         ! If far-field interactions are to be ignored
         if ((pl .eq. -1) .or. (pm .eq. -1)) then
@@ -296,7 +282,7 @@ subroutine params_init(model, force, eps, kappa, eta, se, lmax, ngrid, &
     ! available.
     if (nproc .lt. 0) then
         call update_error(error, "params_init: invalid value of `nproc`")
-        return
+        params % nproc = 1
     else if (nproc .eq. 0) then
         params % nproc = 1
     else
@@ -306,7 +292,6 @@ subroutine params_init(model, force, eps, kappa, eta, se, lmax, ngrid, &
     ! Number of atoms
     if (nsph .le. 0) then
         call update_error(error, "params_init: invalid value of `nsph`")
-        return
     end if
     params % nsph = nsph
     allocate(params % csph(3, nsph), params % rsph(nsph), stat=info)
@@ -321,8 +306,10 @@ subroutine params_init(model, force, eps, kappa, eta, se, lmax, ngrid, &
         params % matvecmem = matvecmem
     else
         call update_error(error, "params_init: invalid value of `matvecmem`")
-        return
     end if
+
+    if (error % flag .ne. 0) return
+
     ! init log
     call init_printing(params, error)
     if (error % flag .ne. 0) then

--- a/src/ddx_pcm.f90
+++ b/src/ddx_pcm.f90
@@ -202,7 +202,7 @@ subroutine ddpcm_solve(params, constants, workspace, state, tol, error)
     finish_time = omp_get_wtime()
     state % xs_time = finish_time - start_time
 
-    if (workspace % error_flag .ne. 0) then
+    if (error % flag .ne. 0) then
         call update_error(error, "ddpcm_solve: solver for ddCOSMO " // &
             & "system did not converge, exiting")
         return

--- a/src/ddx_pcm.f90
+++ b/src/ddx_pcm.f90
@@ -51,8 +51,23 @@ subroutine ddpcm(params, constants, workspace, state, phi_cav, &
     real(dp), intent(out), optional :: force(3, params % nsph)
 
     call ddpcm_setup(params, constants, workspace, state, phi_cav, psi, error)
+    if (error % flag .ne. 0) then
+        call update_error(error,
+            "ddlpb: ddpcm_setup returned an error, exiting")
+        return
+    end if
     call ddpcm_guess(params, constants, workspace, state, error)
+    if (error % flag .ne. 0) then
+        call update_error(error,
+            "ddlpb: ddpcm_guess returned an error, exiting")
+        return
+    end if
     call ddpcm_solve(params, constants, workspace, state, tol, error)
+    if (error % flag .ne. 0) then
+        call update_error(error,
+            "ddlpb: ddpcm_solve returned an error, exiting")
+        return
+    end if
 
     call ddpcm_energy(constants, state, esolv, error)
 
@@ -60,13 +75,24 @@ subroutine ddpcm(params, constants, workspace, state, phi_cav, &
     if (params % force .eq. 1) then
         ! solve the adjoint
         call ddpcm_guess_adjoint(params, constants, workspace, state, error)
+        if (error % flag .ne. 0) then
+            call update_error(error,
+                "ddlpb: ddpcm_guess_adjoint returned an error, exiting")
+            return
+        end if
         call ddpcm_solve_adjoint(params, constants, workspace, state, &
             & tol, error)
+        if (error % flag .ne. 0) then
+            call update_error(error,
+                "ddlpb: ddpcm_guess_adjoint returned an error, exiting")
+            return
+        end if
 
         ! evaluate the solvent unspecific contribution analytical derivatives
         force = zero
         call ddpcm_solvation_force_terms(params, constants, workspace, &
             & state, force, error)
+        end if
     end if
 
 end subroutine ddpcm

--- a/src/ddx_pcm.f90
+++ b/src/ddx_pcm.f90
@@ -52,20 +52,20 @@ subroutine ddpcm(params, constants, workspace, state, phi_cav, &
 
     call ddpcm_setup(params, constants, workspace, state, phi_cav, psi, error)
     if (error % flag .ne. 0) then
-        call update_error(error,
-            "ddlpb: ddpcm_setup returned an error, exiting")
+        call update_error(error, &
+            & "ddlpb: ddpcm_setup returned an error, exiting")
         return
     end if
     call ddpcm_guess(params, constants, workspace, state, error)
     if (error % flag .ne. 0) then
-        call update_error(error,
-            "ddlpb: ddpcm_guess returned an error, exiting")
+        call update_error(error, &
+            & "ddlpb: ddpcm_guess returned an error, exiting")
         return
     end if
     call ddpcm_solve(params, constants, workspace, state, tol, error)
     if (error % flag .ne. 0) then
-        call update_error(error,
-            "ddlpb: ddpcm_solve returned an error, exiting")
+        call update_error(error, &
+            & "ddlpb: ddpcm_solve returned an error, exiting")
         return
     end if
 
@@ -76,15 +76,15 @@ subroutine ddpcm(params, constants, workspace, state, phi_cav, &
         ! solve the adjoint
         call ddpcm_guess_adjoint(params, constants, workspace, state, error)
         if (error % flag .ne. 0) then
-            call update_error(error,
-                "ddlpb: ddpcm_guess_adjoint returned an error, exiting")
+            call update_error(error, &
+                & "ddlpb: ddpcm_guess_adjoint returned an error, exiting")
             return
         end if
         call ddpcm_solve_adjoint(params, constants, workspace, state, &
             & tol, error)
         if (error % flag .ne. 0) then
-            call update_error(error,
-                "ddlpb: ddpcm_guess_adjoint returned an error, exiting")
+            call update_error(error, &
+                & "ddlpb: ddpcm_guess_adjoint returned an error, exiting")
             return
         end if
 
@@ -92,7 +92,6 @@ subroutine ddpcm(params, constants, workspace, state, phi_cav, &
         force = zero
         call ddpcm_solvation_force_terms(params, constants, workspace, &
             & state, force, error)
-        end if
     end if
 
 end subroutine ddpcm

--- a/src/ddx_pcm.f90
+++ b/src/ddx_pcm.f90
@@ -218,8 +218,8 @@ end subroutine ddpcm_solve
 !! @param[inout] workspace : Preallocated workspaces
 !! @param[inout] state     : Solutions, guesses and relevant quantities
 !! @param[in] tol          : Tolerance for the iterative solvers
-!!
 !! @param[inout] error: ddX error
+!!
 subroutine ddpcm_solve_adjoint(params, constants, workspace, state, tol, error)
     implicit none
     type(ddx_params_type), intent(in) :: params

--- a/src/ddx_solvers.f90
+++ b/src/ddx_solvers.f90
@@ -307,10 +307,10 @@ subroutine jacobi_diis_external(params, constants, workspace, n, tol, rhs, x, n_
       ! Jacobi iterations
       do it = 1, n_iter
         ! y = rhs - O x
-        call matvec(params, constants, workspace, x, y )
+        call matvec(params, constants, workspace, x, y, error)
         y = rhs - y
         ! x_new = D^-1 y
-        call dm1vec(params, constants, workspace, y, x_new)
+        call dm1vec(params, constants, workspace, y, x_new, error)
         ! DIIS extrapolation
         if (dodiis) then
           x_diis(:,nmat) = x_new

--- a/src/ddx_solvers.f90
+++ b/src/ddx_solvers.f90
@@ -20,7 +20,7 @@ implicit none
 ! Interfaces
 interface
     ! Interface for the matrix-vector product function
-    subroutine matvec_interface(params, constants, workspace, x, y)
+    subroutine matvec_interface(params, constants, workspace, x, y, error)
         !! Add definitions for derived types
         use ddx_core
         !! Inputs
@@ -31,11 +31,13 @@ interface
         type(ddx_workspace_type), intent(inout) :: workspace
         ! Output
         real(dp), intent(out) :: y(constants % nbasis, params % nsph)
+        type(ddx_error_type), intent(inout) :: error
     end subroutine matvec_interface
 
     ! Interface for the matrix-vector product function for external jacobi_diis.
     ! note that the dimension of x and y is double for ddlpb.
-    subroutine matvec_interface_external(params, constants, workspace, x, y)
+    subroutine matvec_interface_external(params, constants, workspace, x, y, &
+            & error)
         !! Add definitions for derived types
         use ddx_core
         !! Inputs
@@ -46,6 +48,7 @@ interface
         type(ddx_workspace_type), intent(inout) :: workspace
         ! Output
         real(dp), intent(out) :: y(constants % nbasis, params % nsph, 2)
+        type(ddx_error_type), intent(inout) :: error
     end subroutine matvec_interface_external
 
     ! Interface for the norm calculating function
@@ -76,8 +79,10 @@ contains
 !! @param[in] matvec: Routine that performs
 !! @param[in] dm1vec:
 !! @param[in] norm_func:
+!! @param[inout] error: ddX error
+!!
 subroutine jacobi_diis(params, constants, workspace, tol, rhs, x, niter, &
-        & x_rel_diff, matvec, dm1vec, norm_func)
+        & x_rel_diff, matvec, dm1vec, norm_func, error)
     !! Inputs
     type(ddx_params_type), intent(in) :: params
     type(ddx_constants_type), intent(in) :: constants
@@ -88,6 +93,7 @@ subroutine jacobi_diis(params, constants, workspace, tol, rhs, x, niter, &
     real(dp), intent(inout) :: x(constants % n)
     integer, intent(inout) :: niter
     real(dp), intent(out) :: x_rel_diff(niter)
+    type(ddx_error_type), intent(inout) :: error
     !! External procedures
     procedure(matvec_interface) :: matvec, dm1vec
     procedure(norm_interface) :: norm_func
@@ -100,11 +106,19 @@ subroutine jacobi_diis(params, constants, workspace, tol, rhs, x, niter, &
     ! Iterations
     do it = 1, niter
         ! y = rhs - O x
-        call matvec(params, constants, workspace, x, workspace % tmp_y)
+        call matvec(params, constants, workspace, x, workspace % tmp_y, error)
         workspace % tmp_y = rhs - workspace % tmp_y
+        if (error % flag .ne. 0) then
+            call update_error(error, 'Matvec error, exiting')
+            return
+        end if
         ! x_new = D^-1 y
         call dm1vec(params, constants, workspace, workspace % tmp_y, &
-            & workspace % tmp_x_new)
+            & workspace % tmp_x_new, error)
+        if (error % flag .ne. 0) then
+            call update_error(error, 'Preconditioning error, exiting')
+            return
+        end if
         ! DIIS extrapolation
         if (params % jacobi_ndiis .gt. 2) then
             workspace % tmp_x_diis(:, nmat) = workspace % tmp_x_new
@@ -141,9 +155,7 @@ subroutine jacobi_diis(params, constants, workspace, tol, rhs, x, niter, &
             return
         end if
     end do
-    workspace % error_flag = 1
-    workspace % error_message = "Jacobi solver did not converge"
-    return
+    call update_error(error, "Jacobi solver did not converge")
 endsubroutine jacobi_diis
 
 !> DIIS helper routine
@@ -251,7 +263,7 @@ end subroutine makeb
 !! - uses copies of the norm subroutine, so that it can also be called with 
 !!   a user-given size for arrays
 subroutine jacobi_diis_external(params, constants, workspace, n, tol, rhs, x, n_iter, &
-          & x_rel_diff, matvec, dm1vec, norm_func)
+          & x_rel_diff, matvec, dm1vec, norm_func, error)
       type(ddx_params_type),    intent(in)    :: params
       type(ddx_constants_type), intent(inout) :: constants
       type(ddx_workspace_type), intent(inout) :: workspace
@@ -262,6 +274,7 @@ subroutine jacobi_diis_external(params, constants, workspace, n, tol, rhs, x, n_
       ! Outputs
       real(dp),  dimension(n),  intent(inout) :: x
       integer,                  intent(inout) :: n_iter
+      type(ddx_error_type), intent(inout) :: error
       real(dp), intent(out) :: x_rel_diff(n_iter)
       external                                :: matvec, dm1vec
       procedure(norm_interface)               :: norm_func
@@ -278,9 +291,8 @@ subroutine jacobi_diis_external(params, constants, workspace, n, tol, rhs, x, n_
         lenb = params % jacobi_ndiis + 1
         allocate( x_diis(n,params % jacobi_ndiis), e_diis(n,params % jacobi_ndiis), bmat(lenb,lenb) , stat=istatus )
         if (istatus .ne. 0) then
-          workspace % error_flag = 1
-          workspace % error_message = ' jacobi_diis: [1] failed allocation (diis)'
-          return
+            call update_error(error, 'jacobi_diis_external: failed allocation (diis)')
+            return
         endif
         ! initialize the number of points for diis to one.
         ! note that nmat is updated by diis.
@@ -289,8 +301,7 @@ subroutine jacobi_diis_external(params, constants, workspace, n, tol, rhs, x, n_
       ! allocate workspaces
       allocate( x_new(n), y(n) , stat=istatus )
       if (istatus .ne. 0) then
-          workspace % error_flag = 1
-          workspace % error_message = ' jacobi_diis: [2] failed allocation (diis)'
+          call update_error(error, 'jacobi_diis_external: failed allocation (diis)')
           return
       endif
       ! Jacobi iterations
@@ -331,10 +342,7 @@ subroutine jacobi_diis_external(params, constants, workspace, n, tol, rhs, x, n_
             return
         end if
       enddo
-
-      workspace % error_flag = 1
-      workspace % error_message = ' jacobi_diis: [2] failed allocation (diis)'
-
+      call update_error(error, 'Jacobi external solver failed to converge')
 endsubroutine jacobi_diis_external
 
 end module ddx_solvers

--- a/src/ddx_workspace.f90
+++ b/src/ddx_workspace.f90
@@ -100,10 +100,6 @@ type ddx_workspace_type
     real(dp), allocatable :: ddcosmo_guess(:,:), hsp_guess(:,:)
     !> ddLPB temporary timings
     real(dp) :: xs_time, s_time, hsp_time, hsp_adj_time
-    !> Flag if there were an error
-    integer :: error_flag = 0
-    !> Last error message
-    character(len=255) :: error_message
 end type ddx_workspace_type
 
 contains
@@ -289,237 +285,180 @@ end subroutine workspace_init
 !! @param[out] workspace: Preallocated workspaces
 !! @param[inout] error: ddX error
 !!
-subroutine workspace_free(workspace)
+subroutine workspace_free(workspace, error)
     implicit none
     type(ddx_workspace_type), intent(out) :: workspace
+    type(ddx_error_type), intent(inout) :: error
     integer :: istat
 
     istat = 0
-    workspace % error_message = ''
-    workspace % error_flag = 0
 
     if (allocated(workspace % tmp_pot)) then
         deallocate(workspace % tmp_pot, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_pot` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_pot` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_vplm)) then
         deallocate(workspace % tmp_vplm, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_vplm` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_vplm` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_vcos)) then
         deallocate(workspace % tmp_vcos, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_vcos` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_vcos` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_vsin)) then
         deallocate(workspace % tmp_vsin, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_vsin` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_vsin` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_work)) then
         deallocate(workspace % tmp_work, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_work` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_work` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_vylm)) then
         deallocate(workspace % tmp_vylm, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_vylm` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_vylm` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_vdylm)) then
         deallocate(workspace % tmp_vdylm, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_vdylm` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_vdylm` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_sph)) then
         deallocate(workspace % tmp_sph, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_sph` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_sph` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_sph2)) then
         deallocate(workspace % tmp_sph2, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_sph2` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_sph2` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_sph_grad)) then
         deallocate(workspace % tmp_sph_grad, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_sph_grad` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_sph_grad` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_sph_l)) then
         deallocate(workspace % tmp_sph_l, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_sph_l` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_sph_l` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_sph_l_grad)) then
         deallocate(workspace % tmp_sph_l_grad, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_sph_l_grad` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_sph_l_grad` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_sph_l_grad2)) then
         deallocate(workspace % tmp_sph_l_grad2, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_sph_l_grad2` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_sph_l_grad2` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_node_m)) then
         deallocate(workspace % tmp_node_m, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_node_m` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_node_m` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_node_l)) then
         deallocate(workspace % tmp_node_l, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_node_l` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_node_l` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_grid)) then
         deallocate(workspace % tmp_grid, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_grid` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_grid` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_grid2)) then
         deallocate(workspace % tmp_grid2, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_grid2` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_grid2` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_cav)) then
         deallocate(workspace % tmp_cav, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_cav` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_cav` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_efld)) then
         deallocate(workspace % tmp_efld, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_efld` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_efld` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_x_new)) then
         deallocate(workspace % tmp_x_new, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_x_new` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_x_new` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_y)) then
         deallocate(workspace % tmp_y, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_y` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_y` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_x_diis)) then
         deallocate(workspace % tmp_x_diis, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_x_diis` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_x_diis` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_e_diis)) then
         deallocate(workspace % tmp_e_diis, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_e_diis` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_e_diis` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_bmat)) then
         deallocate(workspace % tmp_bmat, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_bmat` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_bmat` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_bessel)) then
         deallocate(workspace % tmp_bessel, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_bessel` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_bessel` deallocation failed!")
         end if
     end if
     if (allocated(workspace % ddcosmo_guess)) then
         deallocate(workspace % ddcosmo_guess, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`ddcosmo_guess` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`ddcosmo_guess` deallocation failed!")
         end if
     end if
     if (allocated(workspace % hsp_guess)) then
         deallocate(workspace % hsp_guess, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`hsp_guess` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`hsp_guess` deallocation failed!")
         end if
     end if
     if (allocated(workspace % tmp_rhs)) then
         deallocate(workspace % tmp_rhs, stat=istat)
         if (istat .ne. 0) then
-            workspace % error_message = "`tmp_rhs` deallocation failed!"
-            workspace % error_flag = 1
-            return
+            call update_error(error, "`tmp_rhs` deallocation failed!")
         end if
     end if
 end subroutine workspace_free

--- a/src/ddx_workspace.f90
+++ b/src/ddx_workspace.f90
@@ -101,7 +101,7 @@ type ddx_workspace_type
     !> ddLPB temporary timings
     real(dp) :: xs_time, s_time, hsp_time, hsp_adj_time
     !> Flag if there were an error
-    integer :: error_flag = 2
+    integer :: error_flag = 0
     !> Last error message
     character(len=255) :: error_message
 end type ddx_workspace_type
@@ -139,7 +139,7 @@ subroutine workspace_init(params, constants, workspace, error)
         & stat=info)
     if (info .ne. 0) then
         call update_error(error, "workspace_init: `tmp_vplm`, `tmp_vcos` " // &
-            & "and `tmp_vsin` allocations failed"
+            & "and `tmp_vsin` allocations failed")
         return
     end if
     allocate(workspace % tmp_vylm(constants % vgrid_nbasis, params % nproc), &

--- a/src/pyddx_classes.cpp
+++ b/src/pyddx_classes.cpp
@@ -118,16 +118,18 @@ class Model {
     const int intfmm       = enable_fmm ? 1 : 0;
     const int intincore    = incore ? 1 : 0;
 
+    m_error = ddx_allocate_error();
+
     m_holder = ddx_allocate_model(
           model_id, enable_force, solvent_epsilon, solvent_kappa, eta, shift, lmax,
           n_lebedev, intincore, maxiter, jacobi_n_diis, intfmm, fmm_multipole_lmax,
           fmm_local_lmax, n_proc, n_spheres, sphere_centres.data(), sphere_radii.data(),
-          logfile.size(), logfile.c_str());
+          logfile.size(), logfile.c_str(), m_error);
     throw_if_error();
   }
 
   ~Model() {
-    if (m_holder) ddx_deallocate_model(m_holder);
+    if (m_holder) ddx_deallocate_model(m_holder, error());
     m_holder = nullptr;
   }
   Model(const Model&)            = delete;
@@ -135,9 +137,9 @@ class Model {
 
   // Check for errors
   void throw_if_error() const {
-    if (ddx_get_error_flag(holder()) != 0) {
-      char message[256];
-      ddx_get_error_message(holder(), message, 256);
+    if (ddx_get_error_flag(error()) != 0) {
+      char message[2000];
+      ddx_get_error_message(error(), message, 2000);
       throw std::runtime_error(std::string(message));
     }
   }
@@ -149,6 +151,7 @@ class Model {
   // Return the holder pointer ... internal function. Use only if you know
   // what you are doing.
   void* holder() const { return m_holder; }
+  void* error() const { return m_error; }
 
   bool has_fmm_enabled() const { return 1 == ddx_get_enable_fmm(m_holder); }
   bool has_force_enabled() const { return 1 == ddx_get_enable_force(m_holder); }
@@ -226,12 +229,13 @@ class Model {
  private:
   void* m_holder;
   std::string m_model;
+  void* m_error;
 };
 
 class State {
  public:
   State(std::shared_ptr<Model> model)
-        : m_holder(ddx_allocate_state(model->holder())),
+        : m_holder(ddx_allocate_state(model->holder(), model->error())),
           m_model(model),
           m_solved(false),
           m_solved_adjoint(false) {
@@ -251,18 +255,13 @@ class State {
   }
 
   ~State() {
-    if (m_holder) ddx_deallocate_state(m_holder);
+    if (m_holder) ddx_deallocate_state(m_holder, model()->error());
     m_holder = nullptr;
   }
   State(const State&)            = delete;
   State& operator=(const State&) = delete;
 
   void throw_if_error() const {
-    if (ddx_get_state_error_flag(holder()) != 0) {
-      char message[256];
-      ddx_get_state_error_message(holder(), message, 256);
-      throw std::runtime_error(std::string(message));
-    }
     model()->throw_if_error();
   }
 
@@ -329,10 +328,10 @@ class State {
 
     if (model()->model() == "cosmo") {
       ddx_cosmo_setup(model()->holder(), holder(), model()->n_cav(), model()->n_basis(),
-                      model()->n_spheres(), psi.data(), phi.data());
+                      model()->n_spheres(), psi.data(), phi.data(), model()->error());
     } else if (model()->model() == "pcm") {
       ddx_pcm_setup(model()->holder(), holder(), model()->n_cav(), model()->n_basis(),
-                    model()->n_spheres(), psi.data(), phi.data());
+                    model()->n_spheres(), psi.data(), phi.data(), model()->error());
     } else if (model()->model() == "lpb") {
       if (py_elec_field.is_none()) {
         throw py::value_error("For LPB elec_field needs to be provided.");
@@ -345,7 +344,8 @@ class State {
       }
 
       ddx_lpb_setup(model()->holder(), holder(), model()->n_cav(), model()->n_basis(),
-                    model()->n_spheres(), psi.data(), phi.data(), elec_field.data());
+                    model()->n_spheres(), psi.data(), phi.data(), elec_field.data(),
+                    model()->error());
     } else {
       throw py::value_error("Model " + model()->model() + " not yet implemented.");
     }
@@ -356,11 +356,11 @@ class State {
 
   void fill_guess(double tol) {
     if (model()->model() == "cosmo") {
-      ddx_cosmo_guess(model()->holder(), holder());
+      ddx_cosmo_guess(model()->holder(), holder(), model()->error());
     } else if (model()->model() == "pcm") {
-      ddx_pcm_guess(model()->holder(), holder());
+      ddx_pcm_guess(model()->holder(), holder(), model()->error());
     } else if (model()->model() == "lpb") {
-      ddx_lpb_guess(model()->holder(), holder(), tol);
+      ddx_lpb_guess(model()->holder(), holder(), tol, model()->error());
     } else {
       throw py::value_error("Model " + model()->model() + " not yet implemented.");
     }
@@ -370,11 +370,11 @@ class State {
 
   void fill_guess_adjoint(double tol) {
     if (model()->model() == "cosmo") {
-      ddx_cosmo_guess_adjoint(model()->holder(), holder());
+      ddx_cosmo_guess_adjoint(model()->holder(), holder(), model()->error());
     } else if (model()->model() == "pcm") {
-      ddx_pcm_guess_adjoint(model()->holder(), holder());
+      ddx_pcm_guess_adjoint(model()->holder(), holder(), model()->error());
     } else if (model()->model() == "lpb") {
-      ddx_lpb_guess_adjoint(model()->holder(), holder(), tol);
+      ddx_lpb_guess_adjoint(model()->holder(), holder(), tol, model()->error());
     } else {
       throw py::value_error("Model " + model()->model() + " not yet implemented.");
     }
@@ -385,11 +385,11 @@ class State {
   // Solve the forward COSMO / PCM / LPB System. The state is modified in-place.
   void solve(double tol) {
     if (model()->model() == "cosmo") {
-      ddx_cosmo_solve(model()->holder(), holder(), tol);
+      ddx_cosmo_solve(model()->holder(), holder(), tol, model()->error());
     } else if (model()->model() == "pcm") {
-      ddx_pcm_solve(model()->holder(), holder(), tol);
+      ddx_pcm_solve(model()->holder(), holder(), tol, model()->error());
     } else if (model()->model() == "lpb") {
-      ddx_lpb_solve(model()->holder(), holder(), tol);
+      ddx_lpb_solve(model()->holder(), holder(), tol, model()->error());
     } else {
       throw py::value_error("Model " + model()->model() + " not yet implemented.");
     }
@@ -400,11 +400,11 @@ class State {
   // Solve the adjoint COSMO / PCM / LPB System. The state is modified in-place.
   void solve_adjoint(double tol) {
     if (model()->model() == "cosmo") {
-      ddx_cosmo_solve_adjoint(model()->holder(), holder(), tol);
+      ddx_cosmo_solve_adjoint(model()->holder(), holder(), tol, model()->error());
     } else if (model()->model() == "pcm") {
-      ddx_pcm_solve_adjoint(model()->holder(), holder(), tol);
+      ddx_pcm_solve_adjoint(model()->holder(), holder(), tol, model()->error());
     } else if (model()->model() == "lpb") {
-      ddx_lpb_solve_adjoint(model()->holder(), holder(), tol);
+      ddx_lpb_solve_adjoint(model()->holder(), holder(), tol, model()->error());
     } else {
       throw py::value_error("Model " + model()->model() + " not yet implemented.");
     }
@@ -417,11 +417,11 @@ class State {
     check_solved();
     double ret = 0.0;
     if (model()->model() == "cosmo") {
-      ret = ddx_cosmo_energy(model()->holder(), holder());
+      ret = ddx_cosmo_energy(model()->holder(), holder(), model()->error());
     } else if (model()->model() == "pcm") {
-      ret = ddx_pcm_energy(model()->holder(), holder());
+      ret = ddx_pcm_energy(model()->holder(), holder(), model()->error());
     } else if (model()->model() == "lpb") {
-      ret = ddx_lpb_energy(model()->holder(), holder());
+      ret = ddx_lpb_energy(model()->holder(), holder(), model()->error());
     } else {
       throw py::value_error("Model " + model()->model() + " not yet implemented.");
     }
@@ -435,10 +435,10 @@ class State {
     array_f_t forces({3, model()->n_spheres()});
     if (model()->model() == "cosmo") {
       ddx_cosmo_solvation_force_terms(model()->holder(), holder(), model()->n_spheres(),
-                                      forces.mutable_data());
+                                      forces.mutable_data(), model()->error());
     } else if (model()->model() == "pcm") {
       ddx_pcm_solvation_force_terms(model()->holder(), holder(), model()->n_spheres(),
-                                    forces.mutable_data());
+                                    forces.mutable_data(), model()->error());
     } else if (model()->model() == "lpb") {
       throw py::value_error(
             "Forces not yet fully implemented for ddLPB on the python side.");
@@ -470,7 +470,7 @@ class State {
     array_f_t forces({3, model()->n_spheres()});
     ddx_multipole_forces(model()->holder(), holder(), model()->n_spheres(),
                          model()->n_cav(), multipoles.shape(0), multipoles.data(),
-                         e.data(), forces.mutable_data());
+                         e.data(), forces.mutable_data(), model()->error());
     throw_if_error();
     return forces;
   }
@@ -543,14 +543,14 @@ py::dict multipole_electrostatics(std::shared_ptr<Model> model, array_f_t multip
   if (derivative_order == 0) {
     ddx_multipole_electrostatics_0(model->holder(), model->n_spheres(), model->n_cav(),
                                    multipoles.shape(0), multipoles.data(),
-                                   phi.mutable_data());
+                                   phi.mutable_data(), model->error());
     model->throw_if_error();
     return py::dict("phi"_a = phi);
   } else if (derivative_order == 1) {
     array_f_t e({3, model->n_cav()});
     ddx_multipole_electrostatics_1(model->holder(), model->n_spheres(), model->n_cav(),
                                    multipoles.shape(0), multipoles.data(),
-                                   phi.mutable_data(), e.mutable_data());
+                                   phi.mutable_data(), e.mutable_data(), model->error());
     model->throw_if_error();
     return py::dict("phi"_a = phi, "e"_a = e);
   } else if (derivative_order == 2) {
@@ -558,7 +558,8 @@ py::dict multipole_electrostatics(std::shared_ptr<Model> model, array_f_t multip
     array_f_t g({3, 3, model->n_cav()});
     ddx_multipole_electrostatics_2(
           model->holder(), model->n_spheres(), model->n_cav(), multipoles.shape(0),
-          multipoles.data(), phi.mutable_data(), e.mutable_data(), g.mutable_data());
+          multipoles.data(), phi.mutable_data(), e.mutable_data(), g.mutable_data(),
+          model->error());
     model->throw_if_error();
     return py::dict("phi"_a = phi, "e"_a = e, "g"_a = g);
   } else {
@@ -579,7 +580,8 @@ array_f_t multipole_psi(std::shared_ptr<Model> model, array_f_t multipoles) {
 
   array_f_t psi({model->n_basis(), model->n_spheres()});
   ddx_multipole_psi(model->holder(), model->n_basis(), model->n_spheres(),
-                    multipoles.shape(0), multipoles.data(), psi.mutable_data());
+                    multipoles.shape(0), multipoles.data(), psi.mutable_data(),
+                    model->error());
   model->throw_if_error();
   return psi;
 }

--- a/src/pyddx_classes.cpp
+++ b/src/pyddx_classes.cpp
@@ -151,6 +151,8 @@ class Model {
   // Return the holder pointer ... internal function. Use only if you know
   // what you are doing.
   void* holder() const { return m_holder; }
+  // Return the error pointer ... internal function. Use only if you know
+  // what you are doing.
   void* error() const { return m_error; }
 
   bool has_fmm_enabled() const { return 1 == ddx_get_enable_fmm(m_holder); }

--- a/src/pyddx_classes.cpp
+++ b/src/pyddx_classes.cpp
@@ -138,8 +138,8 @@ class Model {
   // Check for errors
   void throw_if_error() const {
     if (ddx_get_error_flag(error()) != 0) {
-      char message[2000];
-      ddx_get_error_message(error(), message, 2000);
+      char message[2047];
+      ddx_get_error_message(error(), message, 2047);
       throw std::runtime_error(std::string(message));
     }
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,3 +94,4 @@ ddx_add_test("matrix_adjoint.f90" "${CMAKE_CURRENT_SOURCE_DIR}/data/ddlpb_force.
 ddx_add_test("matrix_solvers.f90" "${CMAKE_CURRENT_SOURCE_DIR}/data/ddlpb_force.txt")
 ddx_add_test("m2l.f90")
 ddx_add_test("multipolar_solutes.f90")
+ddx_add_test("error.f90")

--- a/tests/ddlpb_esolv.f90
+++ b/tests/ddlpb_esolv.f90
@@ -195,9 +195,11 @@ subroutine solve(ddx_data, esolv_in, n_iter, epsilon_solv, eta, kappa, lmax, tol
         & ddx_data % params % maxiter, &
         & ddx_data % params % jacobi_ndiis, &
         & ddx_data % params % nproc, dummy_file_name, ddx_data2, error2)
+    call check_error(error2)
 
     ! the state depends on lmax, so it is allocated here
-    call ddx_init_state(ddx_data2 % params, ddx_data2 % constants, state)
+    call ddx_init_state(ddx_data2 % params, ddx_data2 % constants, state, error2)
+    call check_error(error2)
 
     allocate(phi_cav2(ddx_data2 % constants % ncav), gradphi_cav2(3, ddx_data2 % constants % ncav), &
             & hessianphi_cav2(3, 3, ddx_data2 % constants % ncav), &

--- a/tests/ddlpb_esolv.f90
+++ b/tests/ddlpb_esolv.f90
@@ -160,7 +160,7 @@ deallocate(default_epsilon, default_eta, &
 
 if (istatus.ne.0) write(6,*) 'Deallocation failed'
 
-call ddfree(ddx_data)
+call ddfree(ddx_data, error)
 
 contains
 
@@ -219,8 +219,8 @@ subroutine solve(ddx_data, esolv_in, n_iter, epsilon_solv, eta, kappa, lmax, tol
     n_iter = state % x_lpb_niter
     deallocate(phi_cav2, gradphi_cav2, hessianphi_cav2, psi2, force2)
 
-    call ddx_free_state(state)
-    call ddfree(ddx_data2)
+    call ddx_free_state(state, error2)
+    call ddfree(ddx_data2, error2)
 end subroutine solve
 
 ! This subroutine checks if the default and computed values are same

--- a/tests/ddlpb_esolv.f90
+++ b/tests/ddlpb_esolv.f90
@@ -23,6 +23,7 @@ implicit none
 
 character(len=255) :: fname
 type(ddx_type) :: ddx_data
+type(ddx_error_type) :: error
 
 real(dp) :: esolv, default_value, tol
 integer :: i, istatus, default_lmax_val, n_iter
@@ -38,8 +39,8 @@ character(len=255) :: dummy_file_name = ''
 ! Read input file name
 call getarg(1, fname)
 write(*, *) "Using provided file ", trim(fname), " as a config file"
-call ddfromfile(fname, ddx_data, tol, charges)
-if(ddx_data % error_flag .ne. 0) stop "Initialization failed"
+call ddfromfile(fname, ddx_data, tol, charges, error)
+call check_error(error)
 
 ! Allocation for variable vectors
 ! default_"variable_name" : These are the precomputed values
@@ -177,6 +178,7 @@ subroutine solve(ddx_data, esolv_in, n_iter, epsilon_solv, eta, kappa, lmax, tol
 
     type(ddx_state_type) :: state
     type(ddx_type) :: ddx_data2
+    type(ddx_error_type) :: error2
     real(dp), allocatable :: phi_cav2(:)
     real(dp), allocatable :: gradphi_cav2(:,:)
     real(dp), allocatable :: hessianphi_cav2(:,:,:)
@@ -192,7 +194,7 @@ subroutine solve(ddx_data, esolv_in, n_iter, epsilon_solv, eta, kappa, lmax, tol
         & eta, epsilon_solv, kappa, 0,&
         & ddx_data % params % maxiter, &
         & ddx_data % params % jacobi_ndiis, &
-        & ddx_data % params % nproc, dummy_file_name, ddx_data2)
+        & ddx_data % params % nproc, dummy_file_name, ddx_data2, error2)
 
     ! the state depends on lmax, so it is allocated here
     call ddx_init_state(ddx_data2 % params, ddx_data2 % constants, state)

--- a/tests/ddlpb_esolv.f90
+++ b/tests/ddlpb_esolv.f90
@@ -213,7 +213,8 @@ subroutine solve(ddx_data, esolv_in, n_iter, epsilon_solv, eta, kappa, lmax, tol
         &  1, phi_cav2, 1, gradphi_cav2, 1, hessianphi_cav2, psi2, charges)
     gradphi_cav2 = - gradphi_cav2
     call ddsolve(ddx_data2, state, phi_cav2, gradphi_cav2, hessianphi_cav2, &
-        & psi2, tol, esolv_in, force2)
+        & psi2, tol, esolv_in, force2, error2)
+    call check_error(error2)
 
     n_iter = state % x_lpb_niter
     deallocate(phi_cav2, gradphi_cav2, hessianphi_cav2, psi2, force2)

--- a/tests/ddx_core.f90
+++ b/tests/ddx_core.f90
@@ -389,6 +389,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "correct test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check different correct inputs with different n <= 10 (hardcoded value)
     do i = 1, 10
         call ddinit(i, x, y, z, rvdw, model, lmax, ngrid, force, fmm, &
@@ -398,6 +399,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`nsph` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     ! Check incorrect input nsph <= 0
     i = 0
@@ -407,6 +409,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`nsph` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = -1
     call ddinit(i, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -414,15 +417,18 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`nsph` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check all possible models (1, 2, 3) with other correct inputs
     do i = 1, 3
-        write(*, *) "model=", i
+        write(*, *) "model=", i, n
         call ddinit(n, x, y, z, rvdw, i, lmax, ngrid, force, fmm, pm, &
             & pl, se, eta, eps, kappa, matvecmem, &
             & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        call print_error(error)
         if (error % flag .ne. 0) call test_error(-1, "`model` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     ! Check incorrect models
     i = -1
@@ -432,6 +438,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`model` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = 4
     call ddinit(n, x, y, z, rvdw, i, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -439,6 +446,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`model` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct lmax >= 0
     !do i = 0, 6
     do i = 1, 6
@@ -449,6 +457,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`lmax` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     ! Check incorrect lmax < 0
     i = -1
@@ -458,6 +467,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`lmax` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct ngrid >= 0
     do i = 1, nllg
         j = ng0(i)
@@ -467,6 +477,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`ngrid` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     ! Check incorrect ngrid < 0
     i = -1
@@ -476,6 +487,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`ngrid` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct force (0, 1)
     do i = 0, 1
         call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, i, fmm, pm, &
@@ -484,6 +496,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`force` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     ! Check incorrect force
     i = -1
@@ -493,6 +506,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`force` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = 2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, i, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -500,6 +514,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`force` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct fmm (0, 1)
     do i = 0, 1
         call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, i, &
@@ -508,6 +523,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`fmm` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     ! Check incorrect fmm
     i = -1
@@ -517,6 +533,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`fmm` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = 2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, i, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -524,6 +541,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`fmm` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct pm (ignored if fmm=0)
     j = 0
     do i = -2, 2
@@ -533,6 +551,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`pm` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     ! Check correct pm (fmm=1)
     j = 1
@@ -543,6 +562,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`pm` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, &
@@ -551,6 +571,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`pm` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check incorrect pm (fmm=1)
     j = 1
     i = -2
@@ -560,6 +581,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`pm` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct pl (ignored if fmm=0)
     j = 0
     do i = -2, 2
@@ -569,6 +591,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`pl` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     ! Check correct pl (fmm=1)
     j = 1
@@ -579,6 +602,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`pl` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, &
@@ -587,6 +611,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`pl` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check incorrect pl (fmm=1)
     j = 1
     i = -2
@@ -596,6 +621,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`pl` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct se (interval [-1,1])
     tmp = -one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -604,6 +630,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = zero
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, tmp, eta, eps, kappa, matvecmem, &
@@ -611,6 +638,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, tmp, eta, eps, kappa, matvecmem, &
@@ -618,6 +646,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check incorrect se
     tmp = 1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -626,6 +655,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = -1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, tmp, eta, eps, kappa, matvecmem, &
@@ -633,6 +663,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct eta (interval [0,1])
     tmp = pt5
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -641,6 +672,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, tmp, eps, kappa, matvecmem, &
@@ -648,6 +680,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check incorrect eta
     tmp = -0.0000005
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -656,6 +689,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = 1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, tmp, eps, kappa, matvecmem, &
@@ -663,6 +697,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = -1d-2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, tmp, eps, kappa, matvecmem, &
@@ -670,6 +705,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct eps
     tmp = 1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -678,6 +714,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = dble(1000)
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
@@ -685,6 +722,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check incorrect eps
     tmp = zero
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -693,6 +731,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = pt5
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
@@ -700,6 +739,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
@@ -707,6 +747,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = -1d-2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
@@ -714,6 +755,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct kappa
     tmp = 1d-2
     j = 3 ! only referenced in case of LPB model
@@ -723,6 +765,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`kappa` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     tmp = -1d-2 ! not referenced in case of COSMO and PCM models
     do j = 1, 2
         call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
@@ -731,6 +774,7 @@ subroutine check_ddinit_args()
         if (error % flag .ne. 0) call test_error(-1, "`kappa` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
+        call reset_error(error)
     end do
     ! Check incorrect kappa
     j = 3
@@ -741,6 +785,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`kappa` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct matvecmem
     i = 0
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
@@ -749,6 +794,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = 1
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, i, &
@@ -756,6 +802,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = -1
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, i, &
@@ -763,6 +810,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = 2
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, i, &
@@ -770,6 +818,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct maxiter
     i = 1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -778,6 +827,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = 1000000
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -785,6 +835,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check incorrect maxiter
     i = 0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -793,6 +844,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -800,6 +852,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct ndiis
     i = 0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -808,6 +861,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = 1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -815,6 +869,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = 1000
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -822,6 +877,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check incorrect jacobi_ndiis
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -830,6 +886,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check correct nproc
     i = 0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -838,6 +895,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = 1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -845,6 +903,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     ! Check incorrect nproc
     i = 2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -853,6 +912,7 @@ subroutine check_ddinit_args()
     if (error % flag .ne. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
@@ -860,6 +920,7 @@ subroutine check_ddinit_args()
     if (error % flag .eq. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
+    call reset_error(error)
 end subroutine check_ddinit_args
 
 ! Check Legendre polynomials
@@ -2471,8 +2532,8 @@ subroutine check_tree_rib(alpha)
     real(dp) :: csph(3, nsph), rsph(nsph), csph2(3, nsph), rsph2(nsph), &
         & cnode(3, 2*nsph-1), rnode(2*nsph-1)
     integer :: order(nsph), i, reorder(nsph), cluster(2, 2*nsph-1), &
-        & children(2, 2*nsph-1), parent(2*nsph-1), snode(nsph), flag
-    character (len=255) message
+        & children(2, 2*nsph-1), parent(2*nsph-1), snode(nsph)
+    type(ddx_error_type) :: error
     ! Scale inputs
     csph(:, 1) = alpha * (/1d0, 1d0, 1d0/)
     csph(:, 2) = alpha * (/2d0, 2d0, 2d0/)
@@ -2494,7 +2555,7 @@ subroutine check_tree_rib(alpha)
     end do
     ! Build a recursive inertial binary tree
     call tree_rib_build(nsph, csph2, rsph2, reorder, cluster, children, &
-        & parent, cnode, rnode, snode, message, flag)
+        & parent, cnode, rnode, snode, error)
 end subroutine check_tree_rib
 
 !subroutine check_tree_m2m(p, alpha)

--- a/tests/ddx_core.f90
+++ b/tests/ddx_core.f90
@@ -388,7 +388,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "correct test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check different correct inputs with different n <= 10 (hardcoded value)
     do i = 1, 10
@@ -398,7 +398,7 @@ subroutine check_ddinit_args()
             & dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`nsph` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     ! Check incorrect input nsph <= 0
@@ -408,7 +408,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`nsph` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = -1
     call ddinit(i, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -416,7 +416,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`nsph` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check all possible models (1, 2, 3) with other correct inputs
     do i = 1, 3
@@ -427,7 +427,7 @@ subroutine check_ddinit_args()
         call print_error(error)
         if (error % flag .ne. 0) call test_error(-1, "`model` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     ! Check incorrect models
@@ -437,7 +437,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`model` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = 4
     call ddinit(n, x, y, z, rvdw, i, lmax, ngrid, force, fmm, pm, &
@@ -445,7 +445,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`model` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct lmax >= 0
     !do i = 0, 6
@@ -456,7 +456,7 @@ subroutine check_ddinit_args()
             & nproc, dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`lmax` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     ! Check incorrect lmax < 0
@@ -466,7 +466,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`lmax` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct ngrid >= 0
     do i = 1, nllg
@@ -476,7 +476,7 @@ subroutine check_ddinit_args()
             & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`ngrid` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     ! Check incorrect ngrid < 0
@@ -486,7 +486,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`ngrid` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct force (0, 1)
     do i = 0, 1
@@ -495,7 +495,7 @@ subroutine check_ddinit_args()
             & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`force` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     ! Check incorrect force
@@ -505,7 +505,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`force` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = 2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, i, fmm, pm, &
@@ -513,7 +513,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`force` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct fmm (0, 1)
     do i = 0, 1
@@ -522,7 +522,7 @@ subroutine check_ddinit_args()
             & matvecmem, maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`fmm` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     ! Check incorrect fmm
@@ -532,7 +532,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`fmm` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = 2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, i, pm, &
@@ -540,7 +540,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`fmm` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct pm (ignored if fmm=0)
     j = 0
@@ -550,7 +550,7 @@ subroutine check_ddinit_args()
             & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`pm` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     ! Check correct pm (fmm=1)
@@ -561,7 +561,7 @@ subroutine check_ddinit_args()
             & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`pm` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     i = -1
@@ -570,7 +570,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`pm` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check incorrect pm (fmm=1)
     j = 1
@@ -580,7 +580,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`pm` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct pl (ignored if fmm=0)
     j = 0
@@ -590,7 +590,7 @@ subroutine check_ddinit_args()
             & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`pl` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     ! Check correct pl (fmm=1)
@@ -601,7 +601,7 @@ subroutine check_ddinit_args()
             & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`pl` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     i = -1
@@ -610,7 +610,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`pl` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check incorrect pl (fmm=1)
     j = 1
@@ -620,7 +620,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`pl` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct se (interval [-1,1])
     tmp = -one
@@ -629,7 +629,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = zero
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -637,7 +637,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -645,7 +645,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check incorrect se
     tmp = 1.01d0
@@ -654,7 +654,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = -1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -662,7 +662,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct eta (interval [0,1])
     tmp = pt5
@@ -671,7 +671,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -679,7 +679,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check incorrect eta
     tmp = -0.0000005
@@ -688,7 +688,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = 1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -696,7 +696,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = -1d-2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -704,7 +704,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct eps
     tmp = 1.01d0
@@ -713,7 +713,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = dble(1000)
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -721,7 +721,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check incorrect eps
     tmp = zero
@@ -730,7 +730,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = pt5
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -738,7 +738,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -746,7 +746,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = -1d-2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -754,7 +754,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct kappa
     tmp = 1d-2
@@ -764,7 +764,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`kappa` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     tmp = -1d-2 ! not referenced in case of COSMO and PCM models
     do j = 1, 2
@@ -773,7 +773,7 @@ subroutine check_ddinit_args()
             & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
         if (error % flag .ne. 0) call test_error(-1, "`kappa` test failed in " // &
             & "check_ddinit_args()")
-        call ddfree(ddx_data)
+        call ddfree(ddx_data, error)
         call reset_error(error)
     end do
     ! Check incorrect kappa
@@ -784,7 +784,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`kappa` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct matvecmem
     i = 0
@@ -793,7 +793,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = 1
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
@@ -801,7 +801,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = -1
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
@@ -809,7 +809,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = 2
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
@@ -817,7 +817,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct maxiter
     i = 1
@@ -826,7 +826,7 @@ subroutine check_ddinit_args()
         & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = 1000000
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -834,7 +834,7 @@ subroutine check_ddinit_args()
         & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check incorrect maxiter
     i = 0
@@ -843,7 +843,7 @@ subroutine check_ddinit_args()
         & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -851,7 +851,7 @@ subroutine check_ddinit_args()
         & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct ndiis
     i = 0
@@ -860,7 +860,7 @@ subroutine check_ddinit_args()
         & maxiter, i, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = 1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -868,7 +868,7 @@ subroutine check_ddinit_args()
         & maxiter, i, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = 1000
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -876,7 +876,7 @@ subroutine check_ddinit_args()
         & maxiter, i, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check incorrect jacobi_ndiis
     i = -1
@@ -885,7 +885,7 @@ subroutine check_ddinit_args()
         & maxiter, i, nproc, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check correct nproc
     i = 0
@@ -894,7 +894,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = 1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -902,7 +902,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     ! Check incorrect nproc
     i = 2
@@ -911,7 +911,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data, error)
     if (error % flag .ne. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
@@ -919,7 +919,7 @@ subroutine check_ddinit_args()
         & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data, error)
     if (error % flag .eq. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
     call reset_error(error)
 end subroutine check_ddinit_args
 
@@ -2760,7 +2760,7 @@ end subroutine check_tree_rib
 !    write(*, "(A,/)") repeat("=", 40)
 !    if (.not. ok) stop 1
 !    ! Deallocate tree
-!    call ddfree(ddx_data)
+!    call ddfree(ddx_data, error)
 !end subroutine check_tree_m2m
 !
 !subroutine check_tree_l2l(p, alpha)
@@ -2993,7 +2993,7 @@ end subroutine check_tree_rib
 !    end if
 !    if (.not. ok) stop 1
 !    ! Deallocate tree
-!    call ddfree(ddx_data)
+!    call ddfree(ddx_data, error)
 !end subroutine check_tree_l2l
 !
 !subroutine check_tree_m2l(pm, pl, alpha, threshold)
@@ -3243,7 +3243,7 @@ end subroutine check_tree_rib
 !    end if
 !    if (.not. ok) stop 1
 !    ! Deallocate tree
-!    call ddfree(ddx_data)
+!    call ddfree(ddx_data, error)
 !end subroutine check_tree_m2l
 !
 !subroutine check_tree_l2p(p, alpha, threshold)

--- a/tests/ddx_core.f90
+++ b/tests/ddx_core.f90
@@ -355,13 +355,13 @@ end if
 
 contains
 !> Print error message and exit with provided error code
-subroutine error(code, message)
+subroutine test_error(code, message)
     integer, intent(in) :: code
     character(len=*), intent(in) :: message
     write(0, "(A,A)") "ERROR: ", message
     write(0, "(A,I2)") "CODE:  ", code
     stop -1
-end subroutine
+end subroutine test_error
 
 subroutine check_ddinit_args()
     ! Example of correct args
@@ -371,6 +371,7 @@ subroutine check_ddinit_args()
     real(dp) :: x(10), y(10), z(10), rvdw(10), se=zero, eta=1d-1, &
         & eps=1.1d1, kappa=1d0
     type(ddx_type) :: ddx_data
+    type(ddx_error_type) :: error
     integer :: i, j
     real(dp) :: tmp
     character(len=255) :: dummy_file_name = ''
@@ -384,8 +385,8 @@ subroutine check_ddinit_args()
     ! Check correct input
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "correct test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "correct test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check different correct inputs with different n <= 10 (hardcoded value)
@@ -393,8 +394,8 @@ subroutine check_ddinit_args()
         call ddinit(i, x, y, z, rvdw, model, lmax, ngrid, force, fmm, &
             & pm, pl, se, eta, eps, kappa, matvecmem, &
             & maxiter, jacobi_ndiis, nproc, &
-            & dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`nsph` test failed in " // &
+            & dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`nsph` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
@@ -402,15 +403,15 @@ subroutine check_ddinit_args()
     i = 0
     call ddinit(i, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`nsph` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`nsph` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = -1
     call ddinit(i, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`nsph` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`nsph` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check all possible models (1, 2, 3) with other correct inputs
@@ -418,8 +419,8 @@ subroutine check_ddinit_args()
         write(*, *) "model=", i
         call ddinit(n, x, y, z, rvdw, i, lmax, ngrid, force, fmm, pm, &
             & pl, se, eta, eps, kappa, matvecmem, &
-            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`model` test failed in " // &
+            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`model` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
@@ -427,15 +428,15 @@ subroutine check_ddinit_args()
     i = -1
     call ddinit(n, x, y, z, rvdw, i, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`model` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`model` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = 4
     call ddinit(n, x, y, z, rvdw, i, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`model` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`model` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct lmax >= 0
@@ -444,8 +445,8 @@ subroutine check_ddinit_args()
         call ddinit(n, x, y, z, rvdw, model, i, ngrid, force, fmm, &
             & pm, pl, se, eta, eps, kappa, &
             & matvecmem, maxiter, jacobi_ndiis, &
-            & nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`lmax` test failed in " // &
+            & nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`lmax` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
@@ -453,8 +454,8 @@ subroutine check_ddinit_args()
     i = -1
     call ddinit(n, x, y, z, rvdw, model, i, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`lmax` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`lmax` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct ngrid >= 0
@@ -462,8 +463,8 @@ subroutine check_ddinit_args()
         j = ng0(i)
         call ddinit(n, x, y, z, rvdw, model, lmax, j, force, fmm, pm, &
             & pl, se, eta, eps, kappa, matvecmem, &
-            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`ngrid` test failed in " // &
+            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`ngrid` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
@@ -471,16 +472,16 @@ subroutine check_ddinit_args()
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, i, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`ngrid` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`ngrid` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct force (0, 1)
     do i = 0, 1
         call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, i, fmm, pm, &
             & pl, se, eta, eps, kappa, matvecmem, &
-            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`force` test failed in " // &
+            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`force` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
@@ -488,23 +489,23 @@ subroutine check_ddinit_args()
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, i, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`force` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`force` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = 2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, i, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`force` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`force` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct fmm (0, 1)
     do i = 0, 1
         call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, i, &
             & pm, pl, se, eta, eps, kappa, &
-            & matvecmem, maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`fmm` test failed in " // &
+            & matvecmem, maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`fmm` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
@@ -512,15 +513,15 @@ subroutine check_ddinit_args()
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, i, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`fmm` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`fmm` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = 2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, i, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`fmm` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`fmm` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct pm (ignored if fmm=0)
@@ -528,8 +529,8 @@ subroutine check_ddinit_args()
     do i = -2, 2
         call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, &
             & i, pl, se, eta, eps, kappa, matvecmem, &
-            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`pm` test failed in " // &
+            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`pm` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
@@ -538,16 +539,16 @@ subroutine check_ddinit_args()
     do i = 0, 20, 5
         call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, &
             & i, pl, se, eta, eps, kappa, matvecmem, &
-            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`pm` test failed in " // &
+            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`pm` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, &
         & i, pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`pm` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`pm` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check incorrect pm (fmm=1)
@@ -555,8 +556,8 @@ subroutine check_ddinit_args()
     i = -2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, i, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`pm` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`pm` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct pl (ignored if fmm=0)
@@ -564,8 +565,8 @@ subroutine check_ddinit_args()
     do i = -2, 2
         call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, &
             & pm, i, se, eta, eps, kappa, matvecmem, &
-            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`pl` test failed in " // &
+            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`pl` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
@@ -574,16 +575,16 @@ subroutine check_ddinit_args()
     do i = 0, 20, 5
         call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, &
             & pm, i, se, eta, eps, kappa, matvecmem, &
-            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`pl` test failed in " // &
+            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`pl` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, &
         & pm, i, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`pl` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`pl` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check incorrect pl (fmm=1)
@@ -591,126 +592,126 @@ subroutine check_ddinit_args()
     i = -2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, j, pm, &
         & i, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`pl` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`pl` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct se (interval [-1,1])
     tmp = -one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, tmp, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`se` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = zero
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, tmp, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`se` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, tmp, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`se` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check incorrect se
     tmp = 1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, tmp, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`se` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = -1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, tmp, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`se` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`se` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct eta (interval [0,1])
     tmp = pt5
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, tmp, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`eta` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, tmp, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`eta` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check incorrect eta
     tmp = -0.0000005
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, tmp, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`eta` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = 1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, tmp, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`eta` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = -1d-2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, tmp, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`eta` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`eta` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct eps
     tmp = 1.01d0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`eps` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = dble(1000)
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`eps` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check incorrect eps
     tmp = zero
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`eps` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = pt5
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`eps` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = one
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`eps` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = -1d-2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, tmp, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`eps` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`eps` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct kappa
@@ -718,16 +719,16 @@ subroutine check_ddinit_args()
     j = 3 ! only referenced in case of LPB model
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, tmp, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`kappa` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`kappa` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     tmp = -1d-2 ! not referenced in case of COSMO and PCM models
     do j = 1, 2
         call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
             & pl, se, eta, eps, tmp, matvecmem, &
-            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-        if (ddx_data % error_flag .ne. 0) call error(-1, "`kappa` test failed in " // &
+            & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+        if (error % flag .ne. 0) call test_error(-1, "`kappa` test failed in " // &
             & "check_ddinit_args()")
         call ddfree(ddx_data)
     end do
@@ -736,127 +737,127 @@ subroutine check_ddinit_args()
     tmp = -1d-2
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, tmp, matvecmem, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`kappa` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`kappa` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct matvecmem
     i = 0
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, i, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`matvecmem` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = 1
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, i, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`matvecmem` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = -1
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, i, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`matvecmem` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = 2
     call ddinit(n, x, y, z, rvdw, j, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, i, &
-        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`matvecmem` test failed in " // &
+        & maxiter, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`matvecmem` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct maxiter
     i = 1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`maxiter` test failed in " // &
+        & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = 1000000
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`maxiter` test failed in " // &
+        & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check incorrect maxiter
     i = 0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`maxiter` test failed in " // &
+        & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`maxiter` test failed in " // &
+        & i, jacobi_ndiis, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`maxiter` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct ndiis
     i = 0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, i, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`jacobi_ndiis` test failed in " // &
+        & maxiter, i, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = 1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, i, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`jacobi_ndiis` test failed in " // &
+        & maxiter, i, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = 1000
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, i, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`jacobi_ndiis` test failed in " // &
+        & maxiter, i, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check incorrect jacobi_ndiis
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, i, nproc, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`jacobi_ndiis` test failed in " // &
+        & maxiter, i, nproc, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`jacobi_ndiis` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check correct nproc
     i = 0
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`nproc` test failed in " // &
+        & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = 1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`nproc` test failed in " // &
+        & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     ! Check incorrect nproc
     i = 2
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .ne. 0) call error(-1, "`nproc` test failed in " // &
+        & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data, error)
+    if (error % flag .ne. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
     i = -1
     call ddinit(n, x, y, z, rvdw, model, lmax, ngrid, force, fmm, pm, &
         & pl, se, eta, eps, kappa, matvecmem, &
-        & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data)
-    if (ddx_data % error_flag .eq. 0) call error(-1, "`nproc` test failed in " // &
+        & maxiter, jacobi_ndiis, i, dummy_file_name, ddx_data, error)
+    if (error % flag .eq. 0) call test_error(-1, "`nproc` test failed in " // &
         & "check_ddinit_args()")
     call ddfree(ddx_data)
 end subroutine check_ddinit_args

--- a/tests/ddx_driver.f90
+++ b/tests/ddx_driver.f90
@@ -49,7 +49,8 @@ if(istatus .ne. 0) call test_error(-1, "Allocation failed")
 call mkrhs(ddx_data % params, ddx_data % constants, ddx_data % workspace, 1, &
     & phi_cav, 1, gradphi_cav, 1, hessianphi_cav, psi, charges)
 ! Use the solver
-call ddsolve(ddx_data, state, phi_cav, gradphi_cav, hessianphi_cav, psi, tol, esolv, force)
+call ddsolve(ddx_data, state, phi_cav, gradphi_cav, hessianphi_cav, psi, tol, esolv, force, error)
+call check_error(error)
 ! compute the second contribution to the forces
 call grad_phi_for_charges(ddx_data % params, ddx_data % constants, &
     & ddx_data % workspace, state, charges, force, -gradphi_cav, error)

--- a/tests/ddx_driver.f90
+++ b/tests/ddx_driver.f90
@@ -85,8 +85,8 @@ end if
 close(100)
 deallocate(phi_cav, gradphi_cav, psi, force, charges, stat=istatus)
 if(istatus .ne. 0) call test_error(-1, "Deallocation failed")
-call ddx_free_state(state)
-call ddfree(ddx_data)
+call ddx_free_state(state, error)
+call ddfree(ddx_data, error)
 
 contains
 !> Print error message and exit with provided error code

--- a/tests/ddx_driver.f90
+++ b/tests/ddx_driver.f90
@@ -52,7 +52,8 @@ call mkrhs(ddx_data % params, ddx_data % constants, ddx_data % workspace, 1, &
 call ddsolve(ddx_data, state, phi_cav, gradphi_cav, hessianphi_cav, psi, tol, esolv, force)
 ! compute the second contribution to the forces
 call grad_phi_for_charges(ddx_data % params, ddx_data % constants, &
-    & ddx_data % workspace, state, charges, force, -gradphi_cav)
+    & ddx_data % workspace, state, charges, force, -gradphi_cav, error)
+call check_error(error)
 ! Open output file for reading
 open(unit=100, file=foutname, form='formatted', access='sequential')
 ! Skip 

--- a/tests/ddx_driver.f90
+++ b/tests/ddx_driver.f90
@@ -36,8 +36,8 @@ read(tmpstr, *) threshold
 ! Init input from a file
 call ddfromfile(finname, ddx_data, tol, charges, error)
 call check_error(error)
-call ddx_init_state(ddx_data % params, ddx_data % constants, state)
-if(state % error_flag .ne. 0) stop "Initialization failed"
+call ddx_init_state(ddx_data % params, ddx_data % constants, state, error)
+call check_error(error)
 
 ! Allocate resources
 allocate(phi_cav(ddx_data % constants % ncav), gradphi_cav(3, ddx_data % constants % ncav), &

--- a/tests/ddx_driver.f90
+++ b/tests/ddx_driver.f90
@@ -18,6 +18,7 @@ implicit none
 
 character(len=255) :: finname, foutname, tmpstr
 type(ddx_type) :: ddx_data
+type(ddx_error_type) :: error
 type(ddx_state_type) :: state
 real(dp), allocatable :: phi_cav(:), gradphi_cav(:, :), &
     & hessianphi_cav(:, :, :), psi(:, :), force(:, :), charges(:)
@@ -33,8 +34,8 @@ call getarg(2, foutname)
 call getarg(3, tmpstr)
 read(tmpstr, *) threshold
 ! Init input from a file
-call ddfromfile(finname, ddx_data, tol, charges)
-if(ddx_data % error_flag .ne. 0) stop "Initialization failed"
+call ddfromfile(finname, ddx_data, tol, charges, error)
+call check_error(error)
 call ddx_init_state(ddx_data % params, ddx_data % constants, state)
 if(state % error_flag .ne. 0) stop "Initialization failed"
 
@@ -43,7 +44,7 @@ allocate(phi_cav(ddx_data % constants % ncav), gradphi_cav(3, ddx_data % constan
     & hessianphi_cav(3, 3, ddx_data % constants % ncav), &
     & psi(ddx_data % constants % nbasis, ddx_data % params % nsph), force(3, ddx_data % params % nsph), &
     & stat=istatus)
-if(istatus .ne. 0) call error(-1, "Allocation failed")
+if(istatus .ne. 0) call test_error(-1, "Allocation failed")
 ! Prepare host-code-related entities
 call mkrhs(ddx_data % params, ddx_data % constants, ddx_data % workspace, 1, &
     & phi_cav, 1, gradphi_cav, 1, hessianphi_cav, psi, charges)
@@ -62,7 +63,7 @@ read(100, "(A)") tmpstr
 read(tmpstr(16:), *) esolv2
 if(abs(esolv2-esolv) .gt. threshold*abs(esolv)) then
     close(100)
-    call error(-1, "Energy is different")
+    call test_error(-1, "Energy is different")
 end if
 ! Compare forces
 if (ddx_data % params % force .eq. 1) then
@@ -75,25 +76,25 @@ if (ddx_data % params % force .eq. 1) then
     fdiff = dnrm2(3*ddx_data % params % nsph, force, 1)
     if(fdiff .gt. threshold*fnorm) then
         close(100)
-        call error(-1, "Forces are different")
+        call test_error(-1, "Forces are different")
     end if
 end if
 ! Close output file and deallocate resources
 close(100)
 deallocate(phi_cav, gradphi_cav, psi, force, charges, stat=istatus)
-if(istatus .ne. 0) call error(-1, "Deallocation failed")
+if(istatus .ne. 0) call test_error(-1, "Deallocation failed")
 call ddx_free_state(state)
 call ddfree(ddx_data)
 
 contains
 !> Print error message and exit with provided error code
-subroutine error(code, message)
+subroutine test_error(code, message)
     integer, intent(in) :: code
     character(len=*), intent(in) :: message
     write(0, "(A,A)") "ERROR: ", message
     write(0, "(A,I2)") "CODE:  ", code
     stop -1
-end subroutine
+end subroutine test_error
 end program main
 
 

--- a/tests/ddx_operators.f90
+++ b/tests/ddx_operators.f90
@@ -58,7 +58,7 @@ do i = 1, size(alpha)
     call check_dx(ddx_data, lmax+1, lmax+1, 1d-4)
     call check_gradr(ddx_data, 40, 40, 1d-12)
     call check_gradr(ddx_data, lmax+2, lmax+2, 1d-3)
-    call ddfree(ddx_data)
+    call ddfree(ddx_data, error)
 end do
 
 contains
@@ -225,7 +225,7 @@ subroutine check_dx(ddx_data, pm, pl, threshold)
         end if
     end do
     ! Free temporary objects
-    call ddfree(ddx_data_fmm)
+    call ddfree(ddx_data_fmm, error)
 end subroutine check_dx
 
 subroutine check_gradr(ddx_data, pm, pl, threshold)
@@ -271,7 +271,7 @@ subroutine check_gradr(ddx_data, pm, pl, threshold)
         call test_error(-1, "Forces are different")
     end if
     deallocate(ygrid, g)
-    call ddfree(ddx_data_fmm)
+    call ddfree(ddx_data_fmm, error)
 end subroutine check_gradr
 
 end program test_ddx_operators

--- a/tests/ddx_operators.f90
+++ b/tests/ddx_operators.f90
@@ -19,6 +19,7 @@ integer :: i, ngrid=590, nproc=1
 ! a*b*c into a*(b*c).
 real(dp) :: alpha(4)=(/1d0, -1d0, 1d-100, 1d+100/)
 type(ddx_type) :: ddx_data
+type(ddx_error_type) :: error
 integer, parameter :: nsph=10, lmax=7, force=1, matvecmem=0, &
     & maxiter=1000, jacobi_ndiis=25
 real(dp), parameter :: se=0d0, eta=0.1d0, eps=78d0, kappa=0d0
@@ -46,7 +47,7 @@ do i = 1, size(alpha)
     call ddinit(nsph, csph(1, :), csph(2, :), csph(3, :), rsph, 2, &
         lmax, ngrid, force, 0, -1, -1, se, eta, eps, kappa, &
         & matvecmem, maxiter, jacobi_ndiis, &
-        & nproc, dummy_file_name, ddx_data)
+        & nproc, dummy_file_name, ddx_data, error)
     call check_mkrhs(ddx_data, 0, 0, 1d-1, charge)
     call check_mkrhs(ddx_data, 1, 1, 1d-2, charge)
     call check_mkrhs(ddx_data, 3, 3, 1d-3, charge)
@@ -62,13 +63,13 @@ end do
 
 contains
 !> Print error message and exit with provided error code
-subroutine error(code, message)
+subroutine test_error(code, message)
     integer, intent(in) :: code
     character(len=*), intent(in) :: message
     write(0, "(A,A)") "ERROR: ", message
     write(0, "(A,I2)") "CODE:  ", code
     stop -1
-end subroutine
+end subroutine test_error
 
 subroutine check_mkrhs(ddx_data, pm, pl, threshold, charges)
     ! Inputs
@@ -78,6 +79,7 @@ subroutine check_mkrhs(ddx_data, pm, pl, threshold, charges)
     real(dp), intent(in) :: charges(ddx_data % params % nsph)
     ! Local variables
     type(ddx_type) :: ddx_data_fmm
+    type(ddx_error_type) :: error
     integer :: info
     real(dp), allocatable :: phi_cav(:), phi2_cav(:), gradphi_cav(:, :), &
         & gradphi2_cav(:, :), hessianphi_cav(:, :, :), &
@@ -93,7 +95,7 @@ subroutine check_mkrhs(ddx_data, pm, pl, threshold, charges)
         & ddx_data % params % eps, ddx_data % params % kappa, ddx_data % params % matvecmem, &
         & ddx_data % params % maxiter, ddx_data % params % jacobi_ndiis, &
         & ddx_data % params % nproc, &
-        & dummy_file_name, ddx_data_fmm)
+        & dummy_file_name, ddx_data_fmm, error)
     ! Allocate resources
     allocate(phi_cav(ddx_data % constants % ncav), &
         & phi2_cav(ddx_data % constants % ncav), &
@@ -105,7 +107,7 @@ subroutine check_mkrhs(ddx_data, pm, pl, threshold, charges)
         & psi2(ddx_data % constants % nbasis, ddx_data % params % nsph), &
         & force(3, ddx_data % params % nsph), &
         & stat=info)
-    if(info .ne. 0) call error(-1, "Allocation failed")
+    if(info .ne. 0) call test_error(-1, "Allocation failed")
     ! Dense operator mkrhs is trusted to have no errors, this must be somehow
     ! checked in the future.
     call mkrhs(ddx_data % params, ddx_data % constants, ddx_data % workspace, &
@@ -121,19 +123,19 @@ subroutine check_mkrhs(ddx_data, pm, pl, threshold, charges)
     fdiff = dnrm2(ddx_data % constants % ncav, phi2_cav, 1)
     print *, "Pot ", fdiff, fnorm, fdiff/fnorm
     if (fdiff .gt. threshold*fnorm) then
-        call error(-1, "Potentials are different")
+        call test_error(-1, "Potentials are different")
     end if
     fnorm = dnrm2(3*ddx_data % constants % ncav, gradphi_cav, 1)
     fdiff = dnrm2(3*ddx_data % constants % ncav, gradphi2_cav, 1)
     print *, "Grad", fdiff, fnorm, fdiff/fnorm
     if (fdiff .gt. threshold*fnorm) then
-        call error(-1, "Gradients are different")
+        call test_error(-1, "Gradients are different")
     end if
     fnorm = dnrm2(9*ddx_data % constants % ncav, hessianphi_cav, 1)
     fdiff = dnrm2(9*ddx_data % constants % ncav, hessianphi2_cav, 1)
     print *, "Hess", fdiff, fnorm, fdiff/fnorm
     if (fdiff .gt. threshold*fnorm) then
-        call error(-1, "Hessians are different")
+        call test_error(-1, "Hessians are different")
     end if
 end subroutine check_mkrhs
 
@@ -144,6 +146,7 @@ subroutine check_dx(ddx_data, pm, pl, threshold)
     real(dp), intent(in) :: threshold
     ! Local variables
     type(ddx_type) :: ddx_data_fmm
+    type(ddx_error_type) :: error
     integer :: irand, iseed(4)=(/0, 0, 0, 1/), do_diag
     integer, parameter :: nrand=10
     real(dp) :: x(ddx_data % constants % nbasis, ddx_data % params % nsph, nrand), &
@@ -159,7 +162,7 @@ subroutine check_dx(ddx_data, pm, pl, threshold)
         & ddx_data % params % eps, ddx_data % params % kappa, ddx_data % params % matvecmem, &
         & ddx_data % params % maxiter, ddx_data % params % jacobi_ndiis, &
         & ddx_data % params % nproc, &
-        & dummy_file_name, ddx_data_fmm)
+        & dummy_file_name, ddx_data_fmm, error)
     ! Dense operator dx is trusted to have no errors, this must be somehow
     ! checked in the future.
     ! Get random x
@@ -180,7 +183,7 @@ subroutine check_dx(ddx_data, pm, pl, threshold)
         diff_norm = dnrm2(ddx_data % constants % n * nrand, y-z, 1)
         write(*, *) "dx_dense vs dx_fmm rel.error=", diff_norm/full_norm
         if (diff_norm .gt. threshold*full_norm) then
-            call error(-1, "FMM dstarx and dense dstarx are different")
+            call test_error(-1, "FMM dstarx and dense dstarx are different")
         end if
         ! Check dense adjoint operator dstarx
         do irand = 1, nrand
@@ -199,7 +202,7 @@ subroutine check_dx(ddx_data, pm, pl, threshold)
         diff_norm = dnrm2(nrand**2, xx-yy, 1)
         write(*, *) "dstarx_dense vs dx_dense rel.error=", diff_norm/full_norm
         if (diff_norm .gt. threshold*full_norm) then
-            call error(-1, "FMM dstarx and dense dstarx are different")
+            call test_error(-1, "FMM dstarx and dense dstarx are different")
         end if
         ! Check FMM adjoint operator dstarx (without precomputed FMM matrices)
         do irand = 1, nrand
@@ -218,7 +221,7 @@ subroutine check_dx(ddx_data, pm, pl, threshold)
         diff_norm = dnrm2(nrand**2, xx-yy, 1)
         write(*, *) "dstarx_fmm vs dx_fmm rel.error=", diff_norm/full_norm
         if (diff_norm .gt. threshold*full_norm) then
-            call error(-1, "FMM dstarx and dense dstarx are different")
+            call test_error(-1, "FMM dstarx and dense dstarx are different")
         end if
     end do
     ! Free temporary objects
@@ -232,6 +235,7 @@ subroutine check_gradr(ddx_data, pm, pl, threshold)
     real(dp), intent(in) :: threshold
     ! Local variables
     type(ddx_type) :: ddx_data_fmm
+    type(ddx_error_type) :: error
     real(dp), allocatable :: ygrid(:,:), g(:,:)
     integer :: iseed(4)=(/0, 0, 0, 1/)
     integer, parameter :: nrand=10
@@ -246,7 +250,7 @@ subroutine check_gradr(ddx_data, pm, pl, threshold)
         & ddx_data % params % eps, ddx_data % params % kappa, ddx_data % params % matvecmem, &
         & ddx_data % params % maxiter, ddx_data % params % jacobi_ndiis, &
         & ddx_data % params % nproc, &
-        & dummy_file_name, ddx_data_fmm)
+        & dummy_file_name, ddx_data_fmm, error)
     ! Dense operator dx is trusted to have no errors, this must be somehow
     ! checked in the future.
     allocate(ygrid(ddx_data % params % ngrid, ddx_data % params % nsph), &
@@ -264,7 +268,7 @@ subroutine check_gradr(ddx_data, pm, pl, threshold)
     write(*, *) 'diff norm', diff_norm
     write(*, *) "gradr dense vs fmm rel.error=", diff_norm / full_norm
     if (diff_norm .gt. threshold*full_norm) then
-        call error(-1, "Forces are different")
+        call test_error(-1, "Forces are different")
     end if
     deallocate(ygrid, g)
     call ddfree(ddx_data_fmm)

--- a/tests/ddx_operators.f90
+++ b/tests/ddx_operators.f90
@@ -173,12 +173,12 @@ subroutine check_dx(ddx_data, pm, pl, threshold)
         ! Random check of FMM dx operator against dense dx operator
         do irand = 1, nrand
             call dx_dense(ddx_data % params, ddx_data % constants, &
-                & ddx_data % workspace, do_diag, x(:, :, irand), y(:, :, irand))
+                & ddx_data % workspace, do_diag, x(:, :, irand), y(:, :, irand), error)
         end do
         full_norm = dnrm2(ddx_data % constants % n * nrand, y, 1)
         do irand = 1, nrand
             call dx_fmm(ddx_data_fmm % params, ddx_data_fmm % constants, &
-                & ddx_data_fmm % workspace, do_diag, x(:, :, irand), z(:, :, irand))
+                & ddx_data_fmm % workspace, do_diag, x(:, :, irand), z(:, :, irand), error)
         end do
         diff_norm = dnrm2(ddx_data % constants % n * nrand, y-z, 1)
         write(*, *) "dx_dense vs dx_fmm rel.error=", diff_norm/full_norm
@@ -188,14 +188,14 @@ subroutine check_dx(ddx_data, pm, pl, threshold)
         ! Check dense adjoint operator dstarx
         do irand = 1, nrand
             call dstarx_dense(ddx_data % params, ddx_data % constants, &
-                & ddx_data % workspace, do_diag, x(:, :, irand), y(:, :, irand))
+                & ddx_data % workspace, do_diag, x(:, :, irand), y(:, :, irand), error)
         end do
         call dgemm('T', 'N', nrand, nrand, ddx_data % constants % n, one, y, ddx_data % constants % n, &
             & y, ddx_data % constants % n, zero, xx, nrand)
         full_norm = dnrm2(nrand**2, xx, 1)
         do irand = 1, nrand
             call dx_dense(ddx_data % params, ddx_data % constants, &
-                & ddx_data % workspace, do_diag, y(:, :, irand), z(:, :, irand))
+                & ddx_data % workspace, do_diag, y(:, :, irand), z(:, :, irand), error)
         end do
         call dgemm('T', 'N', nrand, nrand, ddx_data % constants % n, one, z, ddx_data % constants % n, &
             & x, ddx_data % constants % n, zero, yy, nrand)
@@ -207,14 +207,14 @@ subroutine check_dx(ddx_data, pm, pl, threshold)
         ! Check FMM adjoint operator dstarx (without precomputed FMM matrices)
         do irand = 1, nrand
             call dstarx_fmm(ddx_data_fmm % params, ddx_data_fmm % constants, &
-                & ddx_data_fmm % workspace, do_diag, x(:, :, irand), y(:, :, irand))
+                & ddx_data_fmm % workspace, do_diag, x(:, :, irand), y(:, :, irand), error)
         end do
         call dgemm('T', 'N', nrand, nrand, ddx_data % constants % n, one, y, ddx_data % constants % n, &
             & y, ddx_data % constants % n, zero, xx, nrand)
         full_norm = dnrm2(nrand**2, xx, 1)
         do irand = 1, nrand
             call dx_fmm(ddx_data_fmm % params, ddx_data_fmm % constants, &
-                & ddx_data_fmm % workspace, do_diag, y(:, :, irand), z(:, :, irand))
+                & ddx_data_fmm % workspace, do_diag, y(:, :, irand), z(:, :, irand), error)
         end do
         call dgemm('T', 'N', nrand, nrand, ddx_data % constants % n, one, z, ddx_data % constants % n, &
             & x, ddx_data % constants % n, zero, yy, nrand)

--- a/tests/error.f90
+++ b/tests/error.f90
@@ -1,0 +1,42 @@
+program test_ddx_error
+use ddx_errors
+implicit none
+
+type(ddx_error_type) :: error
+character(len=40) :: ref_text
+
+! we artificially set the max_length to a small value
+error % max_length = 40
+
+call update_error(error, "<1 block of 15>")
+
+ref_text(1:16) = " <1 block of 15>"
+ref_text(17:17) = achar(10)
+
+if (error % message(1:error % message_length) .ne. ref_text(1:error%message_length)) &
+    & stop 1
+
+call update_error(error, "<2 block of 15>")
+ref_text(18:33) = " <2 block of 15>"
+ref_text(34:34) = achar(10)
+
+write(6,"(A,A,A)") error % message(1:error % message_length), "<"
+write(6,"(A,A,A)") ref_text(1:error % message_length), "<"
+
+if (error % message(1:error % message_length) .ne. ref_text(1:error%message_length)) &
+    & stop 2
+
+call update_error(error, "<3 block of 15>")
+ref_text(35:38) = " <3 "
+ref_text(39:39) = achar(10)
+
+if (error % message(1:error % message_length) .ne. ref_text(1:error%message_length)) &
+    & stop 3
+
+call print_error(error)
+call reset_error(error)
+call check_error(error)
+
+contains
+
+end program test_ddx_error

--- a/tests/force.f90
+++ b/tests/force.f90
@@ -44,9 +44,11 @@ allocate(phi_cav(ddx_data % constants % ncav), gradphi_cav(3, ddx_data % constan
 call mkrhs(ddx_data % params, ddx_data % constants, ddx_data % workspace, 1, &
     & phi_cav, 1, gradphi_cav, 1, hessianphi_cav, psi, charges)
 call ddsolve(ddx_data, state, phi_cav, gradphi_cav, hessianphi_cav, psi, &
-    & tol, esolv1, force)
+    & tol, esolv1, force, error)
+call check_error(error)
 call grad_phi_for_charges(ddx_data % params, ddx_data % constants, &
     & ddx_data % workspace, state, charges, force, -gradphi_cav, error)
+call check_error(error)
 
 ddx_data % params % force = 0
 do isph = 1, ddx_data % params % nsph
@@ -103,7 +105,8 @@ subroutine solve(ddx_data, state, tol, esolv, phi_cav, gradphi_cav, &
     call mkrhs(ddx_data2 % params, ddx_data2 % constants, ddx_data2 % workspace, &
         & 1, phi_cav, 1, gradphi_cav, 1, hessianphi_cav, psi, charges)
     call ddsolve(ddx_data2, state, phi_cav, gradphi_cav, hessianphi_cav, psi, tol, esolv, &
-        & force)
+        & force, error2)
+    call check_error(error2)
     call ddfree(ddx_data2)
 end subroutine solve
 

--- a/tests/force.f90
+++ b/tests/force.f90
@@ -73,8 +73,8 @@ do i = 1, ddx_data % params % nsph
 end do
 
 deallocate(phi_cav, gradphi_cav, psi, force, force_num, charges)
-call ddx_free_state(state)
-call ddfree(ddx_data)
+call ddx_free_state(state, error)
+call ddfree(ddx_data, error)
 
 write(*, *) "Rel.error of forces:", relerr
 if (relerr .gt. 1d-5) stop 1
@@ -107,7 +107,7 @@ subroutine solve(ddx_data, state, tol, esolv, phi_cav, gradphi_cav, &
     call ddsolve(ddx_data2, state, phi_cav, gradphi_cav, hessianphi_cav, psi, tol, esolv, &
         & force, error2)
     call check_error(error2)
-    call ddfree(ddx_data2)
+    call ddfree(ddx_data2, error2)
 end subroutine solve
 
 end program main

--- a/tests/force.f90
+++ b/tests/force.f90
@@ -33,8 +33,8 @@ call getarg(1, fname)
 write(*, *) "Using provided file ", trim(fname), " as a config file"
 call ddfromfile(fname, ddx_data, tol, charges, error)
 call check_error(error)
-call ddx_init_state(ddx_data % params, ddx_data % constants, state)
-if(state % error_flag .ne. 0) stop "Initialization failed"
+call ddx_init_state(ddx_data % params, ddx_data % constants, state, error)
+call check_error(error)
 
 allocate(phi_cav(ddx_data % constants % ncav), gradphi_cav(3, ddx_data % constants % ncav), &
     & hessianphi_cav(3, 3, ddx_data % constants % ncav), &

--- a/tests/force.f90
+++ b/tests/force.f90
@@ -46,7 +46,7 @@ call mkrhs(ddx_data % params, ddx_data % constants, ddx_data % workspace, 1, &
 call ddsolve(ddx_data, state, phi_cav, gradphi_cav, hessianphi_cav, psi, &
     & tol, esolv1, force)
 call grad_phi_for_charges(ddx_data % params, ddx_data % constants, &
-    & ddx_data % workspace, state, charges, force, -gradphi_cav)
+    & ddx_data % workspace, state, charges, force, -gradphi_cav, error)
 
 ddx_data % params % force = 0
 do isph = 1, ddx_data % params % nsph

--- a/tests/force_ddlpb.f90
+++ b/tests/force_ddlpb.f90
@@ -19,6 +19,7 @@ implicit none
 
 character(len=255) :: fname
 type(ddx_type) :: ddx_data
+type(ddx_error_type) :: error
 type(ddx_state_type) :: state
 
 real(dp), allocatable :: phi_cav(:), gradphi_cav(:, :), &
@@ -33,8 +34,8 @@ character(len=255) :: dummy_file_name = ''
 ! Read input file name
 call getarg(1, fname)
 write(*, *) "Using provided file ", trim(fname), " as a config file"
-call ddfromfile(fname, ddx_data, tol, charges)
-if(ddx_data % error_flag .ne. 0) stop "Initialization failed"
+call ddfromfile(fname, ddx_data, tol, charges, error)
+call check_error(error)
 call ddx_init_state(ddx_data % params, ddx_data % constants, state)
 
 ! Allocation for variable vectors
@@ -111,6 +112,7 @@ subroutine solve(ddx_data, esolv_in, tol, charges)
     real(dp), intent(in) :: charges(ddx_data % params % nsph)
 
     type(ddx_type) :: ddx_data2
+    type(ddx_error_type) :: error2
     type(ddx_state_type) :: state
     real(dp), allocatable :: phi_cav2(:)
     real(dp), allocatable :: gradphi_cav2(:,:)
@@ -126,7 +128,7 @@ subroutine solve(ddx_data, esolv_in, tol, charges)
         & ddx_data % params % eta, ddx_data % params % eps, ddx_data % params % kappa, &
         & ddx_data % params % matvecmem, ddx_data % params % maxiter, &
         & ddx_data % params % jacobi_ndiis, &
-        & ddx_data % params % nproc, dummy_file_name, ddx_data2)
+        & ddx_data % params % nproc, dummy_file_name, ddx_data2, error2)
 
     call ddx_init_state(ddx_data2 % params, ddx_data2 % constants, state)
 

--- a/tests/force_ddlpb.f90
+++ b/tests/force_ddlpb.f90
@@ -68,9 +68,11 @@ call ddlpb(ddx_data % params, ddx_data % constants, ddx_data % workspace, &
 ! add the solute specific contributions to the forces
 call grad_phi_for_charges(ddx_data % params, &
     & ddx_data % constants, ddx_data % workspace, state, &
-    & charges, force, gradphi_cav)
+    & charges, force, gradphi_cav, error)
+call check_error(error)
 call grad_e_for_charges(ddx_data % params, ddx_data % constants, &
-    & ddx_data % workspace, state, charges, force)
+    & ddx_data % workspace, state, charges, force, error)
+call check_error(error)
 
 do isph = 1, ddx_data % params % nsph
   do i = 1, 3

--- a/tests/force_ddlpb.f90
+++ b/tests/force_ddlpb.f90
@@ -101,8 +101,8 @@ end do
 
 deallocate(phi_cav, gradphi_cav, hessianphi_cav, psi, force, force_num, charges)
 
-call ddx_free_state(state)
-call ddfree(ddx_data)
+call ddx_free_state(state, error)
+call ddfree(ddx_data, error)
 
 write(*, *) "Rel.error of forces:", relerr
 if (relerr .gt. 1.d-5) stop 1
@@ -153,8 +153,8 @@ subroutine solve(ddx_data, esolv_in, tol, charges)
         & psi2, tol, esolv_in, force2, error2)
     call check_error(error2)
 
-    call ddx_free_state(state)
-    call ddfree(ddx_data2)
+    call ddx_free_state(state, error2)
+    call ddfree(ddx_data2, error2)
     deallocate(phi_cav2, gradphi_cav2, hessianphi_cav2, psi2, force2)
 end subroutine solve
 

--- a/tests/force_ddlpb.f90
+++ b/tests/force_ddlpb.f90
@@ -36,7 +36,8 @@ call getarg(1, fname)
 write(*, *) "Using provided file ", trim(fname), " as a config file"
 call ddfromfile(fname, ddx_data, tol, charges, error)
 call check_error(error)
-call ddx_init_state(ddx_data % params, ddx_data % constants, state)
+call ddx_init_state(ddx_data % params, ddx_data % constants, state, error)
+call check_error(error)
 
 ! Allocation for variable vectors
 allocate(phi_cav(ddx_data % constants % ncav), gradphi_cav(3, ddx_data % constants % ncav), &
@@ -129,8 +130,10 @@ subroutine solve(ddx_data, esolv_in, tol, charges)
         & ddx_data % params % matvecmem, ddx_data % params % maxiter, &
         & ddx_data % params % jacobi_ndiis, &
         & ddx_data % params % nproc, dummy_file_name, ddx_data2, error2)
+    call check_error(error2)
 
-    call ddx_init_state(ddx_data2 % params, ddx_data2 % constants, state)
+    call ddx_init_state(ddx_data2 % params, ddx_data2 % constants, state, error2)
+    call check_error(error2)
 
     allocate(phi_cav2(ddx_data2 % constants % ncav), gradphi_cav2(3, ddx_data2 % constants % ncav), &
             & hessianphi_cav2(3, 3, ddx_data2 % constants % ncav), &

--- a/tests/force_ddlpb.f90
+++ b/tests/force_ddlpb.f90
@@ -63,7 +63,8 @@ call mkrhs(ddx_data % params, ddx_data % constants, ddx_data % workspace, &
 gradphi_cav = - gradphi_cav
 
 call ddlpb(ddx_data % params, ddx_data % constants, ddx_data % workspace, &
-    & state, phi_cav, gradphi_cav, psi, tol, esolv, hessianphi_cav, force)
+    & state, phi_cav, gradphi_cav, psi, tol, esolv, hessianphi_cav, force, error)
+call check_error(error)
 
 ! add the solute specific contributions to the forces
 call grad_phi_for_charges(ddx_data % params, &
@@ -149,7 +150,8 @@ subroutine solve(ddx_data, esolv_in, tol, charges)
         & 1, phi_cav2, 1, gradphi_cav2, 1, hessianphi_cav2, psi2, charges)
     gradphi_cav2 = - gradphi_cav2
     call ddsolve(ddx_data2, state, phi_cav2, gradphi_cav2, hessianphi_cav2, &
-        & psi2, tol, esolv_in, force2)
+        & psi2, tol, esolv_in, force2, error2)
+    call check_error(error2)
 
     call ddx_free_state(state)
     call ddfree(ddx_data2)

--- a/tests/matrix_adjoint.f90
+++ b/tests/matrix_adjoint.f90
@@ -16,6 +16,7 @@ implicit none
 
 character(len=255) :: fname
 type(ddx_type) :: ddx_data
+type(ddx_error_type) :: error
 ! isph   : Index for number of spheres
 ! i      : Index for derivative components (i = 1,2,3)
 ! ibasis : Index for number of basis
@@ -77,8 +78,8 @@ real(dp), allocatable :: charges(:)
 ! Read input file name
 call getarg(1, fname)
 write(*, *) "Using provided file ", trim(fname), " as a config file 12"
-call ddfromfile(fname, ddx_data, tol, charges)
-if(ddx_data % error_flag .ne. 0) stop "Initialization failed"
+call ddfromfile(fname, ddx_data, tol, charges, error)
+call check_error(error)
 
 ! lmax0 set to minimum of 6 or given lmax.
 ! nbasis0 set to minimum of 49 or given (lmax+1)^2.

--- a/tests/matrix_adjoint.f90
+++ b/tests/matrix_adjoint.f90
@@ -402,7 +402,7 @@ deallocate(random_vector_nbasis_nsph_two, &
            & vector_C_star_two, &
            & zero_vector, &
            & charges)
-call ddfree(ddx_data)
+call ddfree(ddx_data, error)
 
 write(*, *) "y4(A)x1  :", check_A_one, ", x1(A*)y4  :", check_A_star_one
 write(*, *) "y3(A)x2  :", check_A_two, ", x2(A*)y3  :", check_A_star_two

--- a/tests/matrix_adjoint.f90
+++ b/tests/matrix_adjoint.f90
@@ -235,66 +235,66 @@ random_vector_C_two(:,:,2) = random_vector_nbasis_nsph_four(:,:)
 
 ! Call for matrix A
 call lx(ddx_data % params, ddx_data % constants, &
-          & ddx_data % workspace, random_vector_n_one, vector_A_one)
+          & ddx_data % workspace, random_vector_n_one, vector_A_one, error)
 call lx(ddx_data % params, ddx_data % constants, &
-          & ddx_data % workspace, random_vector_n_two, vector_A_two)
+          & ddx_data % workspace, random_vector_n_two, vector_A_two, error)
 call lx(ddx_data % params, ddx_data % constants, &
-          & ddx_data % workspace, random_vector_n_three, vector_A_three)
+          & ddx_data % workspace, random_vector_n_three, vector_A_three, error)
 call lx(ddx_data % params, ddx_data % constants, &
-          & ddx_data % workspace, random_vector_n_four, vector_A_four)
+          & ddx_data % workspace, random_vector_n_four, vector_A_four, error)
 
 
 ! Call for matrix B
 call bx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_one, vector_B_one)
+      & random_vector_n_one, vector_B_one, error)
 call bx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_two, vector_B_two)
+      & random_vector_n_two, vector_B_two, error)
 call bx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_three, vector_B_three)
+      & random_vector_n_three, vector_B_three, error)
 call bx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_four, vector_B_four)
+      & random_vector_n_four, vector_B_four, error)
 
 ! Call for C1 and C2
 call cx(ddx_data % params, ddx_data % constants, &
                  & ddx_data % workspace, &
                  & random_vector_C_one, &
-                 & vector_C_one)
+                 & vector_C_one, error)
 
 call cx(ddx_data % params, ddx_data % constants, &
                  & ddx_data % workspace, &
                  & random_vector_C_two, &
-                 & vector_C_two)
+                 & vector_C_two, error)
 ! Call for matrix Astar
 call lstarx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_four, vector_A_star_one)
+      & random_vector_n_four, vector_A_star_one, error)
 call lstarx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_three, vector_A_star_two)
+      & random_vector_n_three, vector_A_star_two, error)
 call lstarx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_two, vector_A_star_three)
+      & random_vector_n_two, vector_A_star_three, error)
 call lstarx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_one, vector_A_star_four)
+      & random_vector_n_one, vector_A_star_four, error)
 
 ! Call for matrix Bstar
 call bstarx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_four, vector_B_star_one)
+      & random_vector_n_four, vector_B_star_one, error)
 call bstarx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_three, vector_B_star_two)
+      & random_vector_n_three, vector_B_star_two, error)
 call bstarx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_two, vector_B_star_three)
+      & random_vector_n_two, vector_B_star_three, error)
 call bstarx(ddx_data % params, ddx_data % constants, &
       & ddx_data % workspace, &
-      & random_vector_n_one, vector_B_star_four)
+      & random_vector_n_one, vector_B_star_four, error)
 
 ! Call for C1 and C2 star
 ! |C1* C1*||X3|
@@ -302,12 +302,12 @@ call bstarx(ddx_data % params, ddx_data % constants, &
 call cstarx(ddx_data % params, ddx_data % constants, &
                  & ddx_data % workspace, &
                  & random_vector_C_two, &
-                 & vector_C_star_one)
+                 & vector_C_star_one, error)
 
 call cstarx(ddx_data % params, ddx_data % constants, &
                  & ddx_data % workspace, &
                  & random_vector_C_one, &
-                 & vector_C_star_two)
+                 & vector_C_star_two, error)
 
 !Compute the contraction
 do i = 1, ddx_data % constants % n

--- a/tests/matrix_derivatives.f90
+++ b/tests/matrix_derivatives.f90
@@ -299,6 +299,7 @@ subroutine solve(ddx_data, sum_der_A, sum_der_B, sum_der_Ui, sum_der_C1_C2)
     ! igrid  : Index for grid points
     ! ibasis : Index for number of basis
     integer :: i, isph, igrid, ibasis
+    type(ddx_error_type) :: error
 
     ! Initialise new ddx_data with new centers coordinates
     call ddinit(ddx_data % params % nsph, &
@@ -355,15 +356,15 @@ subroutine solve(ddx_data, sum_der_A, sum_der_B, sum_der_Ui, sum_der_C1_C2)
     zero_vector = zero
     ! Call for matrix A
     call lx(ddx_data2 % params, ddx_data2 % constants, &
-          & ddx_data2 % workspace, random_vector_n_one, vector_cosmo)
+          & ddx_data2 % workspace, random_vector_n_one, vector_cosmo, error)
     ! Call for matrix B
     call bx(ddx_data2 % params, ddx_data2 % constants, &
               & ddx_data2 % workspace, &
-              & random_vector_n_one, vector_lpb)
+              & random_vector_n_one, vector_lpb, error)
     call cx(ddx_data2 % params, ddx_data2 % constants, &
                  & ddx_data2 % workspace, &
                  & random_vector_C_one, &
-                 & vector_c1_c2)
+                 & vector_c1_c2, error)
     ! Sum for U_i^e(x_in)
     do isph = 1,ddx_data2 %  params % nsph
       do igrid = 1,ddx_data2 %  params % ngrid

--- a/tests/matrix_derivatives.f90
+++ b/tests/matrix_derivatives.f90
@@ -164,7 +164,7 @@ call contract_grad_C(ddx_data % params, ddx_data % constants, &
              & random_vector_nbasis_nsph_two, &
              & random_vector_nbasis_nsph_two, &
              & derivative_C1_C2, &
-             & diff_re)
+             & diff_re, error)
 
 do isph = 1, ddx_data % params % nsph
     do i = 1, 3

--- a/tests/matrix_derivatives.f90
+++ b/tests/matrix_derivatives.f90
@@ -247,7 +247,7 @@ deallocate(derivative_num_A, derivative_num_B, derivative_num_Ui, &
            & random_vector_two_evaluated_at_grid, &
            & derivative_C1_C2, &
            & derivative_A, derivative_B, diff_re, derivative_num_C, charges)
-call ddfree(ddx_data)
+call ddfree(ddx_data, error)
 
 write(*, *) "Rel.error of A     :", relerr_A
 write(*, *) "Rel.error of B     :", relerr_B

--- a/tests/matrix_derivatives.f90
+++ b/tests/matrix_derivatives.f90
@@ -280,7 +280,6 @@ subroutine solve(ddx_data, sum_der_A, sum_der_B, sum_der_Ui, sum_der_C1_C2)
     ! Local variables
     ! ddx_data2  : New ddx_data with new coordinates
     type(ddx_type) :: ddx_data2
-    type(ddx_error_type) :: error2
     ! vector_n           : Unit vector of size n\times 1
     ! vector_cosmo            : y = Ax
     ! vector_lpb              : y = Bx

--- a/tests/matrix_derivatives.f90
+++ b/tests/matrix_derivatives.f90
@@ -19,6 +19,7 @@ implicit none
 
 character(len=255) :: fname
 type(ddx_type) :: ddx_data
+type(ddx_error_type) :: error
 character(len=255) :: dummy_file_name = ''
 ! derivative_num_A  : Numerical derivatives for matrix A
 ! derivative_num_B  : Numerical derivatives for matrix B
@@ -77,8 +78,8 @@ real(dp), external :: dnrm2, ddot
 ! Read input file name
 call getarg(1, fname)
 write(*, *) "Using provided file ", trim(fname), " as a config file 12"
-call ddfromfile(fname, ddx_data, tol, charges)
-if(ddx_data % error_flag .ne. 0) stop "Initialization failed"
+call ddfromfile(fname, ddx_data, tol, charges, error)
+call check_error(error)
 
 ! lmax0 set to minimum of 6 or given lmax.
 ! nbasis0 set to minimum of 49 or given (lmax+1)^2.
@@ -279,6 +280,7 @@ subroutine solve(ddx_data, sum_der_A, sum_der_B, sum_der_Ui, sum_der_C1_C2)
     ! Local variables
     ! ddx_data2  : New ddx_data with new coordinates
     type(ddx_type) :: ddx_data2
+    type(ddx_error_type) :: error2
     ! vector_n           : Unit vector of size n\times 1
     ! vector_cosmo            : y = Ax
     ! vector_lpb              : y = Bx
@@ -317,7 +319,7 @@ subroutine solve(ddx_data, sum_der_A, sum_der_B, sum_der_Ui, sum_der_C1_C2)
         & ddx_data % params % kappa, 0, &
         & ddx_data % params % maxiter, &
         & ddx_data % params % jacobi_ndiis, &
-        & ddx_data % params % nproc, dummy_file_name, ddx_data2)
+        & ddx_data % params % nproc, dummy_file_name, ddx_data2, error)
     ! Allocation
     allocate(random_vector_n_one(ddx_data2 % constants % n), &
              & random_vector_n_two(ddx_data2 % constants % n), &

--- a/tests/matrix_solvers.f90
+++ b/tests/matrix_solvers.f90
@@ -22,6 +22,7 @@ implicit none
 
 character(len=255) :: fname
 type(ddx_type) :: ddx_data
+type(ddx_error_type) :: error
 type(ddx_state_type) :: state
 character(len=255) :: dummy_file_name = ''
 
@@ -34,8 +35,8 @@ real(dp), allocatable :: charges(:)
 ! Read input file name
 call getarg(1, fname)
 write(*, *) "Using provided file ", trim(fname), " as a config file"
-call ddfromfile(fname, ddx_data, tol, charges)
-if(ddx_data % error_flag .ne. 0) stop "Initialization failed"
+call ddfromfile(fname, ddx_data, tol, charges, error)
+call check_error(error)
 call ddx_init_state(ddx_data % params, ddx_data % constants, state)
 if(state % error_flag .ne. 0) stop "Initialization failed"
 
@@ -72,6 +73,7 @@ subroutine solve(ddx_data, state, matvecmem, esolv, charges)
     real(dp), intent(in) :: charges(ddx_data % params % nsph)
 
     type(ddx_type) :: ddx_data2
+    type(ddx_error_type) :: error2
     real(dp), allocatable :: phi_cav2(:)
     real(dp), allocatable :: gradphi_cav2(:,:)
     real(dp), allocatable :: hessianphi_cav2(:,:,:)
@@ -87,7 +89,7 @@ subroutine solve(ddx_data, state, matvecmem, esolv, charges)
         & ddx_data % params % eta, ddx_data % params % eps, ddx_data % params % kappa, matvecmem,&
         & ddx_data % params % maxiter, &
         & ddx_data % params % jacobi_ndiis, &
-        & ddx_data % params % nproc, dummy_file_name, ddx_data2)
+        & ddx_data % params % nproc, dummy_file_name, ddx_data2, error2)
 
     allocate(phi_cav2(ddx_data2 % constants % ncav), &
             & gradphi_cav2(3, ddx_data2 % constants % ncav), &

--- a/tests/matrix_solvers.f90
+++ b/tests/matrix_solvers.f90
@@ -37,8 +37,8 @@ call getarg(1, fname)
 write(*, *) "Using provided file ", trim(fname), " as a config file"
 call ddfromfile(fname, ddx_data, tol, charges, error)
 call check_error(error)
-call ddx_init_state(ddx_data % params, ddx_data % constants, state)
-if(state % error_flag .ne. 0) stop "Initialization failed"
+call ddx_init_state(ddx_data % params, ddx_data % constants, state, error)
+call check_error(error)
 
 ! Initial values
 default_value = zero

--- a/tests/matrix_solvers.f90
+++ b/tests/matrix_solvers.f90
@@ -59,8 +59,8 @@ if(abs(esolv_one - esolv_two) .gt. 1e-8) then
   stop 1
 endif
 
-call ddx_free_state(state)
-call ddfree(ddx_data)
+call ddx_free_state(state, error)
+call ddfree(ddx_data, error)
 deallocate(charges)
 
 contains
@@ -110,7 +110,7 @@ subroutine solve(ddx_data, state, matvecmem, esolv, charges)
         & psi2, tol, esolv, force2, error2)
     call check_error(error2)
     deallocate(phi_cav2, gradphi_cav2, hessianphi_cav2, psi2, force2)
-    call ddfree(ddx_data2)
+    call ddfree(ddx_data2, error2)
     return
 end subroutine solve
 

--- a/tests/matrix_solvers.f90
+++ b/tests/matrix_solvers.f90
@@ -107,7 +107,8 @@ subroutine solve(ddx_data, state, matvecmem, esolv, charges)
             &  1, phi_cav2, 1, gradphi_cav2, 1, hessianphi_cav2, psi2, charges)
 
     call ddsolve(ddx_data2, state, phi_cav2, gradphi_cav2, hessianphi_cav2, &
-        & psi2, tol, esolv, force2)
+        & psi2, tol, esolv, force2, error2)
+    call check_error(error2)
     deallocate(phi_cav2, gradphi_cav2, hessianphi_cav2, psi2, force2)
     call ddfree(ddx_data2)
     return

--- a/tests/multipolar_solutes.f90
+++ b/tests/multipolar_solutes.f90
@@ -172,8 +172,10 @@ if (info .ne. 0) call test_error("Deallocation failed in test_multipolar_solutes
 
 ! deallocate
 
-call ddfree(nofmm)
-call ddfree(fmm)
+call ddfree(nofmm, error)
+call check_error(error)
+call ddfree(fmm, error)
+call check_error(error)
 
 contains
 


### PR DESCRIPTION
The error system presented some issues, some of which would have been a problem in the future:
  - code duplication (error stored in 4 different data structures)
  - unavailability of the error when the other data structures are not available (for instance when deallocating)
  - incomplete error propagation

The error system has been reworked to fix the issues:

1) New code for the error handling has been added:
    - Errors are stored in a derived ddx_error_type, which contains a long message and an error flag
    - The errors can be updated by calling the subroutine update_error, this will append a message to the error log and sum 1 to the error flag
    - The errors can be checked by calling check_error, in case of a flag different from zero, the error message will be printed and the program stopped
    
2) The error is now correctly propagated, if a subroutine returns an error, then the caller code takes care of updating the error message and returning.

3) The errors have been decoupled from the other data structures.
    - Previously there was some code duplication as the errors were stored in params, constants, workspace and state. Now all the Fortran API routines expect an error variable and the other data structures do not contain the error.
    - The ddx_cinterface exports a C function for getting a pointer to the ddx_error_type object. All the C API functions expect a pointer to the ddx_error_type as well.
    - The pyddx_classes file was changed as little as possible. The pointer to the ddx_error_type object is stored in the Model class. All the calls to the C API functions get the pointer to the error. The throw_if_error function checks if the error contained in the model is zero, if not, an exception is raised. The throw_if_error function of the State calls the throw_if_error function of the Model.