### PR TITLE
Added initialization of the variables after allocation 

### DIFF
--- a/src/ddx_core.f90
+++ b/src/ddx_core.f90
@@ -451,24 +451,24 @@ subroutine allocate_state(params, constants, state, ddx_error)
     type(ddx_error_type), intent(inout) :: ddx_error
     integer :: istatus
 
-    allocate(state % psi(constants % nbasis, params % nsph), stat=istatus)
+    allocate(state % psi(constants % nbasis, params % nsph), stat=istatus, source=0.0_dp)
     if (istatus .ne. 0) then
         call update_error(ddx_error, "allocate_state: `psi` allocation failed")
         return
     end if
-    allocate(state % phi_cav(constants % ncav), stat=istatus)
+    allocate(state % phi_cav(constants % ncav), stat=istatus, source=0.0_dp)
     if (istatus .ne. 0) then
         call update_error(ddx_error, "allocate_state: `phi_cav` allocation failed")
         return
     end if
-    allocate(state % gradphi_cav(3, constants % ncav), stat=istatus)
+    allocate(state % gradphi_cav(3, constants % ncav), stat=istatus, source=0.0_dp)
     if (istatus .ne. 0) then
         call update_error(ddx_error, &
             & "allocate_state: `gradphi_cav` allocation failed")
         return
     end if
     allocate(state % q(constants % nbasis, &
-        & params % nsph), stat=istatus)
+        & params % nsph), stat=istatus, source=0.0_dp)
     if (istatus .ne. 0) then
         call update_error(ddx_error, "allocate_state: `q` " // &
             & "allocation failed")
@@ -478,55 +478,55 @@ subroutine allocate_state(params, constants, state, ddx_error)
     ! COSMO model
     if (params % model .eq. 1) then
         allocate(state % phi_grid(params % ngrid, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `phi_grid` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % phi(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `phi` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % xs(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `xs` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % xs_rel_diff(params % maxiter), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `xs_rel_diff` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % s(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `s` " // &
             & "allocation failed")
             return
         end if
         allocate(state % s_rel_diff(params % maxiter), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `s_rel_diff` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % sgrid(params % ngrid, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `sgrid` " // &
                 & "allocation failed")
             return
         end if
-        allocate(state % zeta(constants % ncav), stat=istatus)
+        allocate(state % zeta(constants % ncav), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `zeta` " // &
                 & "allocation failed")
@@ -535,111 +535,111 @@ subroutine allocate_state(params, constants, state, ddx_error)
     ! PCM model
     else if (params % model .eq. 2) then
         allocate(state % phi_grid(params % ngrid, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `phi_grid` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % phi(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `phi` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % phiinf(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `phiinf` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % phieps(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `phieps` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % phieps_rel_diff(params % maxiter), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `xs_rel_diff` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % xs(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `xs` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % xs_rel_diff(params % maxiter), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `xs_rel_diff` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % s(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `s` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % s_rel_diff(params % maxiter), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `xs_rel_diff` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % sgrid(params % ngrid, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `sgrid` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % y(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `y` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % y_rel_diff(params % maxiter), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `y_rel_diff` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % ygrid(params % ngrid, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `ygrid` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % g(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `g` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % qgrid(params % ngrid, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `qgrid` " // &
                 & "allocation failed")
             return
         end if
-        allocate(state % zeta(constants % ncav), stat=istatus)
+        allocate(state % zeta(constants % ncav), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `zeta` " // &
                 & "allocation failed")
@@ -648,20 +648,20 @@ subroutine allocate_state(params, constants, state, ddx_error)
     ! LPB model
     else if (params % model .eq. 3) then
         allocate(state % phi_grid(params % ngrid, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `phi_grid` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % phi(constants % nbasis, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `phi` " // &
                 & "allocation failed")
             return
         end if
-        allocate(state % zeta(constants % ncav), stat=istatus)
+        allocate(state % zeta(constants % ncav), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `zeta` " // &
                 & "allocation failed")
@@ -669,7 +669,7 @@ subroutine allocate_state(params, constants, state, ddx_error)
             return
         end if
         allocate(state % x_lpb_rel_diff(params % maxiter), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `x_lpb_rel_diff` " // &
                 & "allocation failed")
@@ -677,7 +677,7 @@ subroutine allocate_state(params, constants, state, ddx_error)
         end if
         allocate(state % rhs_lpb(constants % nbasis, &
             & params % nsph, 2), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `rhs_lpb` " // &
                 & "allocation failed")
@@ -685,7 +685,7 @@ subroutine allocate_state(params, constants, state, ddx_error)
         end if
         allocate(state % rhs_adj_lpb(constants % nbasis, &
             & params % nsph, 2), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `rhs_adj_lpb` " // &
                 & "allocation failed")
@@ -693,69 +693,69 @@ subroutine allocate_state(params, constants, state, ddx_error)
         end if
         allocate(state % x_lpb(constants % nbasis, &
             & params % nsph, 2), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `x_lpb` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % x_adj_lpb(constants % nbasis, &
-            & params % nsph, 2), stat=istatus)
+            & params % nsph, 2), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `x_adj_lpb` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % x_adj_lpb_rel_diff(params % maxiter), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, &
                 & "allocate_state: `x_adj_lpb_rel_diff` allocation failed")
             return
         end if
         allocate(state % g_lpb(params % ngrid, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `g_lpb` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % f_lpb(params % ngrid, &
-            & params % nsph), stat=istatus)
+            & params % nsph), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `f_lpb` " // &
                 & "allocation failed")
             return
         end if
-        allocate(state % zeta_dip(3, constants % ncav), stat=istatus)
+        allocate(state % zeta_dip(3, constants % ncav), stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `zeta_dip` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % x_adj_re_grid(params % ngrid, params % nsph), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `x_adj_re_grid` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % x_adj_r_grid(params % ngrid, params % nsph), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `x_adj_r_grid` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % x_adj_e_grid(params % ngrid, params % nsph), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `x_adj_e_grid` " // &
                 & "allocation failed")
             return
         end if
         allocate(state % phi_n(params % ngrid, params % nsph), &
-            & stat=istatus)
+            & stat=istatus, source=0.0_dp)
         if (istatus .ne. 0) then
             call update_error(ddx_error, "allocate_state: `phi_n` " // &
                 & "allocation failed")

--- a/src/ddx_operators.f90
+++ b/src/ddx_operators.f90
@@ -863,6 +863,7 @@ subroutine prec_tstarx(params, constants, workspace, x, y, ddx_error)
 
     start_time = omp_get_wtime()
     n_iter = params % maxiter
+    workspace % hsp_guess  = zero
     call jacobi_diis(params, constants, workspace, constants % inner_tol, &
         & x(:,:,2), workspace % hsp_guess, n_iter, x_rel_diff, bstarx, &
         & bx_prec, hnorm, ddx_error)


### PR DESCRIPTION
_This PR addresses two minor issues encountered during the self-consistent implementation of ddX._

**Initialization in allocate_state**
While working on the self-consistent implementation of ddX, we noticed that the initial guesses for the direct and adjoint solutions can be problematic. This was traced back to the `allocate_state` routine, where variables are allocated but not initialized to zero, which then leads to insensible guesses. This PR adds zero-initialization to the relevant variables.
This change should not affect the behavior of ddX.

**Jacobi Solver Convergence in ddLPB**
During the implementation of ddLPB, we observed that the Jacobi solver fails to converge after the first SCF iteration. We resolved this by explicitly resetting the `hsp_guess` to zero within the `prec_tstarx` routine.
This change is not expected to affect ddX, as the `hsp_guess` is already set to zero in the beginning, which explains why the first iteration works correctly.