### PR TITLE
Update setup-fortran action

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-      - uses: awvwgk/setup-fortran@main
+      - uses: fortran-lang/setup-fortran@main
         id: setup-fortran
         with:
           compiler: gcc


### PR DESCRIPTION
The setup-fortran action moved to the @fortran-lang org, my original repo will continue working, but it is recommended to change to the new repository.