### PR TITLE
Removed ddx_driver.f90 from the ddX library source files

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -10,7 +10,7 @@ if fc_id == 'gcc'
     '-fbacktrace',
     language: 'fortran',
   )
-elif fc_id == 'intel'
+elif fc_id == 'intel' or fc_id == 'intel-llvm'
   add_project_arguments(
     '-traceback',
     language: 'fortran',

--- a/meson.build
+++ b/meson.build
@@ -91,7 +91,6 @@ ddx_library = library(
   sources: [
     'src/ddx.f90',
     'src/cbessel.f90',
-    'src/ddx_driver.f90',
     'src/ddx_lpb_core.f90',
     'src/ddx_workspace.f90',
     'src/ddx_errors.f90',

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ endif
 
 if lapack_vendor == 'mkl'
   mkl_dep = []
-  if fc_id == 'intel'
+  if fc_id == 'intel' or fc_id == 'intel-llvm'
     mkl_dep += fc.find_library('mkl_intel_lp64')
     if get_option('openmp')
       mkl_dep += fc.find_library('mkl_intel_thread')

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ endif
 
 lapack_vendor = get_option('lapack')
 if lapack_vendor == 'auto'
-  if fc_id == 'intel'
+  if fc_id == 'intel' or fc_id == 'intel-llvm'
     lapack_vendor = 'mkl'
   endif
 endif


### PR DESCRIPTION
**Summary**
This PR removes `src/ddx_driver.f90` from the `ddx_library` source list in `meson.build`

`ddx_driver.f90` defines a Fortran `program main`, so it should only be compiled as the source for the `ddX_exec` executable. Including it in the library means the library may also contain an executable entry point, which can conflict with test executables that define their own `program main`.

Keeping `ddx_driver.f90` only in the `ddX_exec` executable target matches its role as a driver program and keeps the library limited to reusable ddX implementation sources.

